### PR TITLE
Bind singleton instances into the container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added DiContainer component which can be used to register and resolve dependencies
   - Added method `Register<T>` to register a simple service
   - Added method `Register<TKey, TService>` to register a service with a specific implementation
+  - Added method `Register(Type)` to register a simple service
+  - Added method `Register(KeyType, ServiceType)` to register a service with a specific implementation
+  - Added method `Register<T>(Instance)` to register a type with a singleton instance
+  - Added method `Register(Type, Instance)` to register a type with a singleton instance
   - Added method `Override<TKey, TService>` to override any service with a specific implementation
   - Added method `Resolve<T>` to resolve a service
   - Added method `Resolve(Type)` to resolve a service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added method `Register<T>(Instance)` to register a type with a singleton instance
   - Added method `Register(Type, Instance)` to register a type with a singleton instance
   - Added method `Override<TKey, TService>` to override any service with a specific implementation
+  - Added method `Override(KeyType, ServiceType)` to override any service with a specific implementation
+  - Added method `Override<T>(Instance)` to override any service with a specific singleton instance
+  - Added method `Override(Type, Instance)` to override any service with a specific singleton instance
   - Added method `Resolve<T>` to resolve a service
   - Added method `Resolve(Type)` to resolve a service
   - Added method `Clear` to remove any registered service and singleton instance

--- a/Tests/Editor/Container/InstanceBindingTest.cs
+++ b/Tests/Editor/Container/InstanceBindingTest.cs
@@ -49,5 +49,51 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             
             Assert.AreSame(gObj, container.Resolve<GameObject>());
         }
+
+        [Test]
+        public void ItCanOverrideAServiceWithASpecificInstance()
+        {
+            container.Register<SimpleService>();
+            
+            var old = container.Resolve<SimpleService>();
+            
+            var service = new SimpleService();
+            container.Override<SimpleService>(service);
+            
+            var current = container.Resolve<SimpleService>();
+            
+            Assert.AreSame(service, current);
+            Assert.AreNotSame(old, current);
+        }
+
+        [Test]
+        public void ItCanOverrideAnExistingInstance()
+        {
+            var serviceA = new SimpleService();
+            var serviceB = new SimpleService();
+            
+            container.Register<SimpleService>(serviceA);
+            container.Override<SimpleService>(serviceB);
+            
+            var current = container.Resolve<SimpleService>();
+            
+            Assert.AreSame(serviceB, current);
+        }
+
+        [Test]
+        public void ItCanOverrideUsingTypeParameters()
+        {
+            container.Register<SimpleService>();
+            
+            var old = container.Resolve<SimpleService>();
+            
+            var service = new SimpleService();
+            container.Override(typeof(SimpleService), service);
+            
+            var current = container.Resolve<SimpleService>();
+            
+            Assert.AreSame(service, current);
+            Assert.AreNotSame(old, current);
+        }
     }
 }

--- a/Tests/Editor/Container/InstanceBindingTest.cs
+++ b/Tests/Editor/Container/InstanceBindingTest.cs
@@ -1,0 +1,53 @@
+﻿using NUnit.Framework;
+using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
+using TheRealIronDuck.Ducktion.Exceptions;
+using UnityEngine;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
+{
+    public class InstanceBindingTest : DucktionTest
+    {
+        [Test]
+        public void ItCanRegisterSpecificInstances()
+        {
+            var service = new SimpleService();
+
+            container.Register<ISimpleInterface>(service);
+
+            Assert.AreSame(service, container.Resolve<ISimpleInterface>());
+        }
+
+        [Test]
+        public void ItCanRegisterSpecificInstancesUsingTypeParameter()
+        {
+            var service = new SimpleService();
+
+            container.Register(typeof(ISimpleInterface), service);
+
+            Assert.AreSame(service, container.Resolve<ISimpleInterface>());
+        }
+
+        [Test]
+        public void ItThrowsAnExceptionIfTheSpecificInstanceDoesntExtendTheTypeParameter()
+        {
+            var service = new AnotherService();
+
+            var error = Assert.Throws<DependencyRegisterException>(
+                () => container.Register(typeof(ISimpleInterface), service)
+            );
+
+            Assert.That(error.Message, Does.Contain(
+                $"Service {typeof(AnotherService)} does not extend {typeof(ISimpleInterface)}"
+            ));
+        }
+        
+        [Test]
+        public void ItAllowsToRegisterForExampleGameObjectsWhichHaveMultipleConstructors()
+        {
+            var gObj = new GameObject("Hello World!");
+            container.Register<GameObject>(gObj);
+            
+            Assert.AreSame(gObj, container.Resolve<GameObject>());
+        }
+    }
+}

--- a/Tests/Editor/Container/InstanceBindingTest.cs.meta
+++ b/Tests/Editor/Container/InstanceBindingTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 99dcc6e6ef4649c39c226022ceb22d17
+timeCreated: 1699465194

--- a/Tests/Editor/Container/OverrideTest.cs
+++ b/Tests/Editor/Container/OverrideTest.cs
@@ -65,5 +65,34 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             });
             Assert.That(error.Message, Does.Contain("Service is not registered. Use `register` to register the service"));
         }
+
+        [Test]
+        public void ItCanOverrideUsingTypeParameters()
+        {
+            container.Register<ISimpleInterface, SimpleService>();
+
+            var service = container.Resolve<ISimpleInterface>();
+            Assert.IsInstanceOf<SimpleService>(service);
+
+            container.Override(typeof(ISimpleInterface), typeof(SecondSimpleService));
+
+            var secondService = container.Resolve<ISimpleInterface>();
+            Assert.IsInstanceOf<SecondSimpleService>(secondService);
+        }
+
+        [Test]
+        public void ItThrowsAnExceptionIfTheServiceKeyDoesntExtendTheKeyTypeWhenUsingParameters()
+        {
+            container.Register<ISimpleInterface, SimpleService>();
+
+            var error = Assert.Throws<DependencyRegisterException>(() =>
+            {
+                container.Override(typeof(ISimpleInterface), typeof(AnotherService));
+            });
+            
+            Assert.That(error.Message, Does.Contain(
+                $"Service {typeof(AnotherService)} does not extend {typeof(ISimpleInterface)}"
+            ));
+        }
     }
 }

--- a/Tests/Editor/Container/SimpleRegisterResolveTest.cs
+++ b/Tests/Editor/Container/SimpleRegisterResolveTest.cs
@@ -93,5 +93,37 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
                 Does.Contain("Service is already registered. Use `override` to override the service")
             );
         }
+
+        [Test]
+        public void ItCanRegisterWithATypeParameter()
+        {
+            container.Register(typeof(SimpleService));
+
+            var service = container.Resolve<SimpleService>();
+            Assert.IsInstanceOf<SimpleService>(service);
+        }
+
+        [Test]
+        public void ItCanRegisterWithTwoTypeParameters()
+        {
+            container.Register(typeof(ISimpleInterface), typeof(SimpleService));
+
+            var service = container.Resolve<ISimpleInterface>();
+            Assert.IsInstanceOf<SimpleService>(service);
+        }
+
+        [Test]
+        public void ItThrowsAnErrorIfTheServiceDoesntExtendTheKeyWhenUsingTypesAsParameters()
+        {
+            var error = Assert.Throws<DependencyRegisterException>(() =>
+            {
+                container.Register(typeof(ISimpleInterface), typeof(AnotherService));
+            });
+
+            Assert.That(
+                error.Message,
+                Does.Contain($"Service {typeof(AnotherService)} does not extend {typeof(ISimpleInterface)}")
+            );
+        }
     }
 }


### PR DESCRIPTION
### Added
- Added method `Register(Type)` to register a simple service
- Added method `Register(KeyType, ServiceType)` to register a service with a specific implementation
- Added method `Register<T>(Instance)` to register a type with a singleton instance
- Added method `Register(Type, Instance)` to register a type with a singleton instance
- Added method `Override(KeyType, ServiceType)` to override any service with a specific implementation
- Added method `Override<T>(Instance)` to override any service with a specific singleton instance
- Added method `Override(Type, Instance)` to override any service with a specific singleton instance