### PR TITLE
Non Lazy Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The container can automatically resolve dependencies, even if they are not registered
   - This option can be toggled in the configuration
   - Optionally it can be configured if auto resolved services are stored as singletons
+- Services can be marked as lazy or non lazy
+  - Non lazy services will automatically be resolved when the container initializes
 - Services can be registered in configurators
   - Either by using the `IDiConfigurator` interface and manually registering the configurator
   - Or by using the `MonoDiConfigurator` component and adding it to the containers inspector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Optionally it can be configured if auto resolved services are stored as singletons
 - Services can be marked as lazy or non lazy
   - Non lazy services will automatically be resolved when the container initializes
+  - Added methods to service definition:
+    - `SetLazyMode(lazyMode)` to specify the lazy mode
+    - `Lazy()` to mark a service as lazy (Alias for `SetLazyMode(LazyMode.Lazy)`)
+    - `NonLazy()` to mark a service as non-lazy (Alias for `SetLazyMode(LazyMode.NonLazy)`)
 - Services can be registered in configurators
   - Either by using the `IDiConfigurator` interface and manually registering the configurator
   - Or by using the `MonoDiConfigurator` component and adding it to the containers inspector

--- a/Editor/DiContainerInspector.cs
+++ b/Editor/DiContainerInspector.cs
@@ -18,7 +18,7 @@ namespace TheRealIronDuck.Ducktion.Editor
         /// Default spacing between the different boxes.
         /// </summary>
         private const int BoxSpacing = 15;
-        
+
         /// <summary>
         /// Default padding within each box.
         /// </summary>
@@ -38,6 +38,7 @@ namespace TheRealIronDuck.Ducktion.Editor
 
             inspector.Add(BuildGeneralOptionsBox());
             inspector.Add(BuildAutoResolveBox());
+            inspector.Add(BuildDefaultsBox());
             inspector.Add(BuildConfiguratorsBox());
 
             return inspector;
@@ -107,6 +108,31 @@ namespace TheRealIronDuck.Ducktion.Editor
         }
 
         /// <summary>
+        /// Render the box which contains the default options.
+        /// - DefaultLazyMode
+        /// </summary>
+        /// <returns>The defaults box</returns>
+        private Box BuildDefaultsBox()
+        {
+            var defaults = CreateBox("Defaults");
+
+            // HELP BOX
+            defaults.Add(new HelpBox(
+                "You can override any setting here when registering a service. These are the default values " +
+                "which will be used when registering a service without specifying any of these options.",
+                HelpBoxMessageType.Info
+            )
+            {
+                style = { marginBottom = BoxPadding }
+            });
+            // HELP BOX END
+
+            defaults.Add(new PropertyField(serializedObject.FindProperty("defaultLazyMode")));
+
+            return defaults;
+        }
+
+        /// <summary>
         /// Render the box which contains the configurators.
         /// - DefaultConfigurators
         /// </summary>
@@ -128,7 +154,7 @@ namespace TheRealIronDuck.Ducktion.Editor
 
             var defaultConfiguratorsProperty = serializedObject.FindProperty("defaultConfigurators");
             defaultConfiguratorsProperty.isExpanded = true;
-            configurators.Add(new PropertyField(defaultConfiguratorsProperty)); 
+            configurators.Add(new PropertyField(defaultConfiguratorsProperty));
 
             return configurators;
         }

--- a/Runtime/DiContainer.cs
+++ b/Runtime/DiContainer.cs
@@ -300,7 +300,7 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="keyType">The type which gets registered</param>
         /// <param name="serviceType">The concrete implementation type</param>
         /// <exception cref="DependencyRegisterException">If the override fails, it will throw an error</exception>
-        public void Override(Type keyType, Type serviceType)
+        public ServiceDefinition Override(Type keyType, Type serviceType)
         {
             if (!keyType.IsAssignableFrom(serviceType))
             {
@@ -327,6 +327,8 @@ namespace TheRealIronDuck.Ducktion
             _services[keyType] = new ServiceDefinition(serviceType);
 
             _logger.Log(LogLevel.Debug, $"Overridden service: {keyType} => {serviceType}");
+
+            return _services[keyType];
         }
 
         /// <summary>
@@ -338,7 +340,7 @@ namespace TheRealIronDuck.Ducktion
         /// <typeparam name="TKey">The type which gets registered</typeparam>
         /// <typeparam name="TService">The concrete implementation type</typeparam>
         /// <exception cref="DependencyRegisterException">If the override fails, it will throw an error</exception>
-        public void Override<TKey, TService>() where TService : TKey => Override(typeof(TKey), typeof(TService));
+        public ServiceDefinition Override<TKey, TService>() where TService : TKey => Override(typeof(TKey), typeof(TService));
 
         /// <summary>
         /// Override any registered service with a specific instance. The instance will be registered as a singleton
@@ -347,20 +349,12 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="type">The type which gets registered</param>
         /// <param name="instance">The instance which should be returned</param>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Override(Type type, object instance)
+        public ServiceDefinition Override(Type type, object instance)
         {
-            Override(type, instance.GetType());
-            if (!_services.TryGetValue(instance.GetType(), out var definition))
-            {
-                _logger.Log(LogLevel.Error, $"Something went wrong with overriding {type}");
-
-                throw new DependencyRegisterException(
-                    type,
-                    $"Something went wrong with overriding {type}"
-                );
-            }
-
+            var definition = Override(type, instance.GetType());
             definition.Instance = instance;
+            
+            return definition;
         }
 
         /// <summary>
@@ -370,7 +364,7 @@ namespace TheRealIronDuck.Ducktion
         /// <typeparam name="T">The type which gets registered</typeparam>
         /// <param name="instance">The instance which should be returned</param>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Override<T>(T instance) => Override(typeof(T), instance);
+        public ServiceDefinition Override<T>(T instance) => Override(typeof(T), instance);
 
         /// <summary>
         /// Override a service with a callback which gets called on resolve. This is useful if you
@@ -381,7 +375,7 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="keyType">The type which gets registered</param>
         /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
         /// <exception cref="DependencyRegisterException">If the override fails, it will throw an error</exception>
-        public void Override(Type keyType, Func<object> callback)
+        public ServiceDefinition Override(Type keyType, Func<object> callback)
         {
             if (!_services.ContainsKey(keyType))
             {
@@ -397,6 +391,8 @@ namespace TheRealIronDuck.Ducktion
             _services[keyType].Callback = callback;
 
             _logger.Log(LogLevel.Debug, $"Overridden service: {keyType} with callback");
+            
+            return _services[keyType];
         }
 
         /// <summary>
@@ -408,7 +404,7 @@ namespace TheRealIronDuck.Ducktion
         /// <typeparam name="T">The type which gets registered</typeparam>
         /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
         /// <exception cref="DependencyRegisterException">If the override fails, it will throw an error</exception>
-        public void Override<T>(Func<T> callback) => Override(typeof(T), () => callback());
+        public ServiceDefinition Override<T>(Func<T> callback) => Override(typeof(T), () => callback());
 
         /// <summary>
         /// Resolve a given service from the container. It will instantiate the concrete implementation

--- a/Runtime/DiContainer.cs
+++ b/Runtime/DiContainer.cs
@@ -213,7 +213,7 @@ namespace TheRealIronDuck.Ducktion
         /// </summary>
         /// <param name="type">The type which should be registered</param>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Register(Type type) => Register(type, type);
+        public ServiceDefinition Register(Type type) => Register(type, type);
 
         /// <summary>
         /// Register a new service. The service type is used as the key and the concrete implementation.
@@ -232,7 +232,7 @@ namespace TheRealIronDuck.Ducktion
         /// <typeparam name="TKey">The type which gets registered</typeparam>
         /// <typeparam name="TService">The concrete implementation type</typeparam>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Register<TKey, TService>() where TService : TKey => Register(typeof(TKey), typeof(TService));
+        public ServiceDefinition Register<TKey, TService>() where TService : TKey => Register(typeof(TKey), typeof(TService));
 
         /// <summary>
         /// Register a new service and its instance. The service type is used as the key and the concrete implementation.
@@ -241,7 +241,7 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="instance">The instance which should be returned</param>
         /// <typeparam name="T">The type which should be registered</typeparam>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Register<T>(T instance) => Register(typeof(T), instance);
+        public ServiceDefinition Register<T>(T instance) => Register(typeof(T), instance);
 
         /// <summary>
         /// Register a new service and its instance. The service type is used as the key and the concrete implementation.
@@ -250,20 +250,12 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="type">The type which should be registered</param>
         /// <param name="instance">The instance which should be returned</param>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Register(Type type, object instance)
+        public ServiceDefinition Register(Type type, object instance)
         {
-            Register(type, instance.GetType());
-            if (!_services.TryGetValue(type, out var definition))
-            {
-                _logger.Log(LogLevel.Error, $"Something went wrong with registering {type}");
-
-                throw new DependencyRegisterException(
-                    type,
-                    $"Something went wrong with registering {type}"
-                );
-            }
-
+            var definition = Register(type, instance.GetType());
             definition.Instance = instance;
+
+            return definition;
         }
 
         /// <summary>
@@ -275,22 +267,13 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="type">The type which should be registered</param>
         /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Register<T>(Type type, Func<T> callback)
+        public ServiceDefinition Register<T>(Type type, Func<T> callback)
         {
             var serviceType = callback.Method.ReturnType.IsAbstract ? typeof(object) : type;
-            Register(type, serviceType);
-
-            if (!_services.TryGetValue(type, out var definition))
-            {
-                _logger.Log(LogLevel.Error, $"Something went wrong with registering {type}");
-
-                throw new DependencyRegisterException(
-                    type,
-                    $"Something went wrong with registering {type}"
-                );
-            }
-
+            var definition = Register(type, serviceType);
             definition.Callback = () => callback();
+
+            return definition;
         }
 
         /// <summary>
@@ -306,7 +289,7 @@ namespace TheRealIronDuck.Ducktion
         /// <typeparam name="T">The type which should be registered</typeparam>
         /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public void Register<T>(Func<T> callback) => Register(typeof(T), callback);
+        public ServiceDefinition Register<T>(Func<T> callback) => Register(typeof(T), callback);
 
         /// <summary>
         /// Override any registered service with another implementation. Any singleton instance for this type

--- a/Runtime/DiContainer.cs
+++ b/Runtime/DiContainer.cs
@@ -151,15 +151,18 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="newLevel">The log level</param>
         /// <param name="newEnableAutoResolve">Should auto resolve be enabled?</param>
         /// <param name="newAutoResolveSingletonMode">The singleton mode of auto-resolved services</param>
+        /// <param name="newDefaultLazyMode">The default lazy mode</param>
         public void Configure(
             LogLevel newLevel = LogLevel.Error,
             bool newEnableAutoResolve = true,
-            SingletonMode newAutoResolveSingletonMode = SingletonMode.Singleton
+            SingletonMode newAutoResolveSingletonMode = SingletonMode.Singleton,
+            LazyMode newDefaultLazyMode = LazyMode.Lazy
         )
         {
             logLevel = newLevel;
             enableAutoResolve = newEnableAutoResolve;
             autoResolveSingletonMode = newAutoResolveSingletonMode;
+            defaultLazyMode = newDefaultLazyMode;
 
             Reinitialize();
         }

--- a/Runtime/Enums/LazyMode.cs
+++ b/Runtime/Enums/LazyMode.cs
@@ -1,0 +1,13 @@
+namespace TheRealIronDuck.Ducktion.Enums
+{
+    /// <summary>
+    /// This enum is used to define the lazy mode of a service. Lazy means that the service
+    /// will be instantiated only when it is requested. NonLazy means that the service will
+    /// be instantiated when the container is initialized.
+    /// </summary>
+    public enum LazyMode
+    {
+        Lazy,
+        NonLazy
+    }
+}

--- a/Runtime/Enums/LazyMode.cs.meta
+++ b/Runtime/Enums/LazyMode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e213feae7a60468fb76e57a0a1e6fc75
+timeCreated: 1699853487

--- a/Runtime/Enums/SingletonMode.cs
+++ b/Runtime/Enums/SingletonMode.cs
@@ -1,5 +1,8 @@
 ﻿namespace TheRealIronDuck.Ducktion.Enums
 {
+    /// <summary>
+    /// This enum is used to define if a service is a singleton or not.
+    /// </summary>
     public enum SingletonMode
     {
         Singleton,

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -55,8 +55,20 @@ namespace TheRealIronDuck.Ducktion
         /// <summary>
         /// Mark this service as non lazy.
         /// </summary>
-        public void NonLazy() => LazyMode = Enums.LazyMode.NonLazy;
+        public void NonLazy() => SetLazyMode(Enums.LazyMode.NonLazy);
+
+        /// <summary>
+        /// Mark this service as lazy.
+        /// </summary>
+        public void Lazy() => SetLazyMode(Enums.LazyMode.Lazy);
+
+        /// <summary>
+        /// Set the lazy mode of this service.
+        /// </summary>
+        /// <param name="lazyMode">The new lazy mode</param>
+        public void SetLazyMode(LazyMode lazyMode) => LazyMode = lazyMode;
 
         #endregion
+
     }
 }

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -1,17 +1,62 @@
 ﻿using System;
 using JetBrains.Annotations;
+using TheRealIronDuck.Ducktion.Enums;
 
 namespace TheRealIronDuck.Ducktion
 {
+    /// <summary>
+    /// This class hold all the information needed to resolve a service.
+    /// Most variables can't be set directly by the user, but only by the container.
+    /// </summary>
     public class ServiceDefinition
     {
-        public readonly Type ServiceType;
-        [CanBeNull] public object Instance;
-        [CanBeNull] public Func<object> Callback;
+        #region VARIABLES
 
-        public ServiceDefinition(Type serviceType)
+        /// <summary>
+        /// The type of the service. This is the variable that must be passed to the
+        /// `Resolve` method of the container class.
+        /// </summary>
+        public readonly Type ServiceType;
+
+        /// <summary>
+        /// The singleton instance of the service. Can be null if the service is not a singleton
+        /// or if the service has not been resolved yet.
+        ///
+        /// Can only be set by the container.
+        /// </summary>
+        [CanBeNull] public object Instance { get; internal set; }
+
+        /// <summary>
+        /// The given callback to resolve the service. Can be null if no callback was given.
+        ///
+        /// Can only be set by the container.
+        /// </summary>
+        [CanBeNull] public Func<object> Callback { get; internal set; }
+
+        /// <summary>
+        /// Specify if the service should be resolved lazily or not. By default, no lazy mode
+        /// is specified (null), which means that the container will use the default lazy mode.
+        /// </summary>
+        public LazyMode? LazyMode { get; private set; }
+
+        #endregion
+
+        #region LIFECYCLE METHODS
+
+        internal ServiceDefinition(Type serviceType)
         {
             ServiceType = serviceType;
         }
+
+        #endregion
+
+        #region PUBLIC METHODS
+
+        /// <summary>
+        /// Mark this service as non lazy.
+        /// </summary>
+        public void NonLazy() => LazyMode = Enums.LazyMode.NonLazy;
+
+        #endregion
     }
 }

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -55,18 +55,22 @@ namespace TheRealIronDuck.Ducktion
         /// <summary>
         /// Mark this service as non lazy.
         /// </summary>
-        public void NonLazy() => SetLazyMode(Enums.LazyMode.NonLazy);
+        public ServiceDefinition NonLazy() => SetLazyMode(Enums.LazyMode.NonLazy);
 
         /// <summary>
         /// Mark this service as lazy.
         /// </summary>
-        public void Lazy() => SetLazyMode(Enums.LazyMode.Lazy);
+        public ServiceDefinition Lazy() => SetLazyMode(Enums.LazyMode.Lazy);
 
         /// <summary>
         /// Set the lazy mode of this service.
         /// </summary>
         /// <param name="lazyMode">The new lazy mode</param>
-        public void SetLazyMode(LazyMode lazyMode) => LazyMode = lazyMode;
+        public ServiceDefinition SetLazyMode(LazyMode lazyMode)
+        {
+            LazyMode = lazyMode;
+            return this;
+        }
 
         #endregion
 

--- a/Tests/Editor/Container/CallbackBindingTest.cs
+++ b/Tests/Editor/Container/CallbackBindingTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
-using TheRealIronDuck.Ducktion.Enums;
 
 namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 {

--- a/Tests/Editor/Container/ConfiguratorsTest.cs
+++ b/Tests/Editor/Container/ConfiguratorsTest.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using NUnit.Framework;
-using TheRealIronDuck.Ducktion.Configurators;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
 
 namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
+using TheRealIronDuck.Ducktion.Logging;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
+{
+    public class LazyTest : DucktionTest
+    {
+        [Test]
+        public void ItCanRegisterAServiceAsNonLazy()
+        {
+            var logger = FakeLogger();
+
+            container.Register<ServiceWithLogger>().NonLazy();
+            container.Register<SecondServiceWithLogger>();
+            container.Reinitialize();
+
+            logger.AssertHasMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
+            logger.AssertHasNoMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
+        }
+        
+        // TODO: Default can be non lazy
+        // TODO: Default can be non lazy, but I register a lazy service
+        // TODO: Test alias `LazyMode`
+        // TODO: Test every register method syntax
+        // TODO: Test override
+        // TODO: Test every override method syntax
+    }
+}

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -160,7 +160,5 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
                 Is.InstanceOf<ServiceDefinition>()
             );
         }
-
-        // TODO: Test chaining
     }
 }

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -19,12 +19,12 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             logger.AssertHasMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
             logger.AssertHasNoMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
         }
-        
+
         [Test]
         public void ItCanSetTheDefaultToNonLazy()
         {
             var logger = FakeLogger();
-            
+
             container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
 
             container.Register<ServiceWithLogger>();
@@ -34,12 +34,12 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             logger.AssertHasMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
             logger.AssertHasMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
         }
-        
+
         [Test]
         public void ItCanSetTheDefaultToNonLazyButRegisterSpecificServicesAsLazy()
         {
             var logger = FakeLogger();
-            
+
             container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
 
             container.Register<ServiceWithLogger>().Lazy();
@@ -49,12 +49,12 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             logger.AssertHasNoMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
             logger.AssertHasMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
         }
-        
+
         [Test]
         public void ItCanSetTheSpecificLazyModeWithoutANiceMethod()
         {
             var logger = FakeLogger();
-            
+
             container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
 
             container.Register<ServiceWithLogger>().SetLazyMode(LazyMode.Lazy);
@@ -64,8 +64,54 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             logger.AssertHasNoMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
             logger.AssertHasMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
         }
-        
-        // TODO: Test every register method syntax
+
+        [Test]
+        public void ItReturnsTheServiceDefinitionForEveryPossibleRegisterSyntax()
+        {
+            Assert.That(
+                container.Register(typeof(ISimpleInterface), typeof(SimpleService)),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+
+            Assert.That(
+                container.Register(typeof(AnotherService)),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+
+            Assert.That(
+                container.Register<ScalarService>(),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+
+            Assert.That(
+                container.Register<SimpleBaseClass, SimpleService>(),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+
+            Assert.That(
+                container.Register<SimpleService>(new SimpleService()),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+
+            Assert.That(
+                container.Register(typeof(SimpleServiceWithDependency),
+                    new SimpleServiceWithDependency(new AnotherService())),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+            
+            container.Clear();
+            
+            Assert.That(
+                container.Register(typeof(SimpleService), () => new SimpleService()),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+            
+            Assert.That(
+                container.Register<ISimpleInterface>(() => new SimpleService()),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+        }
+
         // TODO: Test override
         // TODO: Test every override method syntax
         // TODO: Test chaining

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
+using TheRealIronDuck.Ducktion.Enums;
 using TheRealIronDuck.Ducktion.Logging;
 
 namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
@@ -19,11 +20,54 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             logger.AssertHasNoMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
         }
         
-        // TODO: Default can be non lazy
-        // TODO: Default can be non lazy, but I register a lazy service
-        // TODO: Test alias `LazyMode`
+        [Test]
+        public void ItCanSetTheDefaultToNonLazy()
+        {
+            var logger = FakeLogger();
+            
+            container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
+
+            container.Register<ServiceWithLogger>();
+            container.Register<SecondServiceWithLogger>();
+            container.Reinitialize();
+
+            logger.AssertHasMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
+            logger.AssertHasMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
+        }
+        
+        [Test]
+        public void ItCanSetTheDefaultToNonLazyButRegisterSpecificServicesAsLazy()
+        {
+            var logger = FakeLogger();
+            
+            container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
+
+            container.Register<ServiceWithLogger>().Lazy();
+            container.Register<SecondServiceWithLogger>();
+            container.Reinitialize();
+
+            logger.AssertHasNoMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
+            logger.AssertHasMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
+        }
+        
+        [Test]
+        public void ItCanSetTheSpecificLazyModeWithoutANiceMethod()
+        {
+            var logger = FakeLogger();
+            
+            container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
+
+            container.Register<ServiceWithLogger>().SetLazyMode(LazyMode.Lazy);
+            container.Register<SecondServiceWithLogger>().SetLazyMode(LazyMode.NonLazy);
+            container.Reinitialize();
+
+            logger.AssertHasNoMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
+            logger.AssertHasMessage(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
+        }
+        
         // TODO: Test every register method syntax
         // TODO: Test override
         // TODO: Test every override method syntax
+        // TODO: Test chaining
     }
 }

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -112,8 +112,55 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             );
         }
 
-        // TODO: Test override
-        // TODO: Test every override method syntax
+        [Test]
+        public void ItCanMarkAServiceAfterwardsAsLazy()
+        {
+            var logger = FakeLogger();
+
+            container.Register<ServiceWithLogger>().Lazy();
+            container.Override<ServiceWithLogger, ServiceWithLogger>().NonLazy();
+            
+            container.Reinitialize();
+
+            logger.AssertHasMessage(LogLevel.Debug, "Hello from ServiceWithLogger!");
+        }
+        
+        [Test]
+        public void ItReturnsTheServiceDefinitionForEveryPossibleOverrideSyntax()
+        {
+            container.Register<ISimpleInterface, SimpleService>();
+            
+            Assert.That(
+                container.Override(typeof(ISimpleInterface), typeof(SimpleService)),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+            
+            Assert.That(
+                container.Override<ISimpleInterface, SimpleService>(),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+            
+            Assert.That(
+                container.Override(typeof(ISimpleInterface), new SimpleService()),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+            
+            Assert.That(
+                container.Override<ISimpleInterface>(new SimpleService()),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+            
+            Assert.That(
+                container.Override(typeof(ISimpleInterface), () => new SimpleService()),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+            
+            Assert.That(
+                container.Override<ISimpleInterface>(() => new SimpleService()),
+                Is.InstanceOf<ServiceDefinition>()
+            );
+        }
+
         // TODO: Test chaining
     }
 }

--- a/Tests/Editor/Container/LazyTest.cs.meta
+++ b/Tests/Editor/Container/LazyTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4ae671092ecc441e89a88b3a40cd9b04
+timeCreated: 1699853817

--- a/Tests/Editor/Fakes/FakeLogger.cs
+++ b/Tests/Editor/Fakes/FakeLogger.cs
@@ -25,5 +25,16 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Fakes
             
             throw new Exception($"Expected to find a log message with level {level} and message {message}");
         }
+        
+        public void AssertHasNoMessage(LogLevel level, string message)
+        {
+            foreach (var (logLevel, logMessage) in Messages)
+            {
+                if (logLevel == level && logMessage == message)
+                {
+                    throw new Exception($"Expected to not find a log message with level {level} and message {message}");
+                }
+            }
+        }
     }
 }

--- a/Tests/Editor/ServiceDefinitionTest.cs
+++ b/Tests/Editor/ServiceDefinitionTest.cs
@@ -1,0 +1,42 @@
+using NUnit.Framework;
+using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
+using TheRealIronDuck.Ducktion.Enums;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
+{
+    public class ServiceDefinitionTest : DucktionTest
+    {
+        [Test]
+        public void ItCreatesAServiceDefinitionWithDefaultValues()
+        {
+            var definition = container.Register<SimpleService>();
+            Assert.That(definition.ServiceType, Is.EqualTo(typeof(SimpleService)));
+            Assert.That(definition.LazyMode, Is.Null);
+            Assert.That(definition.Instance, Is.Null);
+            Assert.That(definition.Callback, Is.Null);
+        }
+
+        [Test]
+        public void ItCanToggleTheLazyMode()
+        {
+            var definition = container.Register<SimpleService>();
+            definition.NonLazy();
+            Assert.That(definition.LazyMode, Is.EqualTo(Enums.LazyMode.NonLazy));
+            
+            definition.Lazy();
+            Assert.That(definition.LazyMode, Is.EqualTo(Enums.LazyMode.Lazy));
+            
+            definition.SetLazyMode(LazyMode.NonLazy);
+            Assert.That(definition.LazyMode, Is.EqualTo(Enums.LazyMode.NonLazy));
+        }
+
+        [Test]
+        public void ItCanFluentlyChangeTheLazyMode()
+        {
+            var definition = container.Register<SimpleService>();
+            definition.NonLazy().Lazy();
+            
+            Assert.That(definition.LazyMode, Is.EqualTo(Enums.LazyMode.Lazy));
+        }
+    }
+}

--- a/Tests/Editor/ServiceDefinitionTest.cs.meta
+++ b/Tests/Editor/ServiceDefinitionTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 32d1d53a45144cefa4cd93531e9bacbe
+timeCreated: 1699900649

--- a/Tests/Editor/Stubs/SecondServiceWithLogger.cs
+++ b/Tests/Editor/Stubs/SecondServiceWithLogger.cs
@@ -1,0 +1,12 @@
+using TheRealIronDuck.Ducktion.Logging;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs
+{
+    public class SecondServiceWithLogger
+    {
+        public SecondServiceWithLogger(DucktionLogger logger)
+        {
+            logger.Log(LogLevel.Debug, "Hello from SecondServiceWithLogger!");
+        }
+    }
+}

--- a/Tests/Editor/Stubs/SecondServiceWithLogger.cs.meta
+++ b/Tests/Editor/Stubs/SecondServiceWithLogger.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a16c4571d9754400962baf6ad1a9c2e8
+timeCreated: 1699854220

--- a/Tests/Editor/Stubs/ServiceWithLogger.cs
+++ b/Tests/Editor/Stubs/ServiceWithLogger.cs
@@ -1,0 +1,12 @@
+using TheRealIronDuck.Ducktion.Logging;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs
+{
+    public class ServiceWithLogger
+    {
+        public ServiceWithLogger(DucktionLogger logger)
+        {
+            logger.Log(LogLevel.Debug, "Hello from ServiceWithLogger!");
+        }
+    }
+}

--- a/Tests/Editor/Stubs/ServiceWithLogger.cs.meta
+++ b/Tests/Editor/Stubs/ServiceWithLogger.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2c5ea6ae8e594f6397a77b85c4b08c3d
+timeCreated: 1699853962


### PR DESCRIPTION
### Added
- Services can be marked as lazy or non lazy
  - Non lazy services will automatically be resolved when the container initializes
  - Added methods to service definition:
    - `SetLazyMode(lazyMode)` to specify the lazy mode
    - `Lazy()` to mark a service as lazy (Alias for `SetLazyMode(LazyMode.Lazy)`)
    - `NonLazy()` to mark a service as non-lazy (Alias for `SetLazyMode(LazyMode.NonLazy)`)