### PR TITLE
Allow to configure singleton modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `SetLazyMode(lazyMode)` to specify the lazy mode
     - `Lazy()` to mark a service as lazy (Alias for `SetLazyMode(LazyMode.Lazy)`)
     - `NonLazy()` to mark a service as non-lazy (Alias for `SetLazyMode(LazyMode.NonLazy)`)
+- Services can be transient or singleton
+  - Transient services will always be resolved as a new instance
+  - Added methods to service definition:
+    - `SetSingletonMode(singletonMode)` to specify the singleton mode
+    - `Singleton()` to mark a service as singleton (Alias for `SetSingletonMode(SingletonMode.Singleton)`)
+    - `NonSingleton()` to mark a service as non-singleton (Alias for `SetSingletonMode(SingletonMode.NonSingleton)`)
+    - `Transient()` as an alias for `NonSingleton()`
 - Services can be registered in configurators
   - Either by using the `IDiConfigurator` interface and manually registering the configurator
   - Or by using the `MonoDiConfigurator` component and adding it to the containers inspector

--- a/Editor/DiContainerInspector.cs
+++ b/Editor/DiContainerInspector.cs
@@ -72,16 +72,10 @@ namespace TheRealIronDuck.Ducktion.Editor
         {
             var autoResolve = CreateBox("Auto Resolve");
 
-            // HELP BOX
-            autoResolve.Add(new HelpBox(
+            autoResolve.Add(CreateHelpBox(
                 "When auto resolving is disabled, you need to manually register all your dependencies. " +
-                "Please read the documentation for more information.",
-                HelpBoxMessageType.Info
-            )
-            {
-                style = { marginBottom = BoxPadding }
-            });
-            // HELP BOX END
+                "Please read the documentation for more information."
+            ));
 
             var enableProperty = serializedObject.FindProperty("enableAutoResolve");
             autoResolve.Add(new PropertyField(enableProperty));
@@ -116,18 +110,37 @@ namespace TheRealIronDuck.Ducktion.Editor
         {
             var defaults = CreateBox("Defaults");
 
-            // HELP BOX
-            defaults.Add(new HelpBox(
+            defaults.Add(CreateHelpBox(
                 "You can override any setting here when registering a service. These are the default values " +
-                "which will be used when registering a service without specifying any of these options.",
-                HelpBoxMessageType.Info
-            )
-            {
-                style = { marginBottom = BoxPadding }
-            });
-            // HELP BOX END
+                "which will be used when registering a service without specifying any of these options."
+            ));
 
             defaults.Add(new PropertyField(serializedObject.FindProperty("defaultLazyMode")));
+
+            defaults.Add(new PropertyField(serializedObject.FindProperty("defaultSingletonMode")));
+
+            // AUTO RESOLVE HELP BOX START
+            var enableProperty = serializedObject.FindProperty("enableAutoResolve");
+
+            var autoResolveNotice = CreateHelpBox(
+                "For auto resolved services, use the configuration field in the `Auto Resolve` box.",
+                HelpBoxMessageType.None
+            );
+            autoResolveNotice.style.marginTop = BoxPadding;
+            autoResolveNotice.style.display = enableProperty.boolValue
+                ? DisplayStyle.Flex
+                : DisplayStyle.None;
+
+            defaults.TrackPropertyValue(enableProperty,
+                _ =>
+                {
+                    autoResolveNotice.style.display =
+                        enableProperty.boolValue ? DisplayStyle.Flex : DisplayStyle.None;
+                }
+            );
+
+            defaults.Add(autoResolveNotice);
+            // AUTO RESOLVE HELP BOX END
 
             return defaults;
         }
@@ -141,16 +154,10 @@ namespace TheRealIronDuck.Ducktion.Editor
         {
             var configurators = CreateBox("Configurators");
 
-            // HELP BOX
-            configurators.Add(new HelpBox(
+            configurators.Add(CreateHelpBox(
                 "Here you may add all configurators which will automatically run on startup. Alternatively, " +
-                "you can manually register them using `AddConfigurator` method.",
-                HelpBoxMessageType.Info
-            )
-            {
-                style = { marginBottom = BoxPadding }
-            });
-            // HELP BOX END
+                "you can manually register them using `AddConfigurator` method."
+            ));
 
             var defaultConfiguratorsProperty = serializedObject.FindProperty("defaultConfigurators");
             defaultConfiguratorsProperty.isExpanded = true;
@@ -194,6 +201,27 @@ namespace TheRealIronDuck.Ducktion.Editor
             box.Add(titleLabel);
 
             return box;
+        }
+
+        /// <summary>
+        /// Small little helper method to create a help box with nice padding.
+        /// </summary>
+        /// <param name="content">The message of the box</param>
+        /// <param name="type">The help box type</param>
+        /// <returns>The generated help box</returns>
+        private static HelpBox CreateHelpBox(string content, HelpBoxMessageType type = HelpBoxMessageType.Info)
+        {
+            return new HelpBox(content, type)
+            {
+                style =
+                {
+                    marginBottom = BoxPadding,
+                    paddingLeft = BoxPadding / 1.5f,
+                    paddingRight = BoxPadding / 1.5f,
+                    paddingTop = BoxPadding / 1.5f,
+                    paddingBottom = BoxPadding / 1.5f
+                }
+            };
         }
 
         #endregion

--- a/Runtime/DiContainer.cs
+++ b/Runtime/DiContainer.cs
@@ -56,6 +56,14 @@ namespace TheRealIronDuck.Ducktion
         /// if no other lazy mode is specified during registration.
         /// </summary>
         [SerializeField] private LazyMode defaultLazyMode = LazyMode.Lazy;
+        
+        /// <summary>
+        /// Specify the default singleton mode any service should be registered with. This will only
+        /// be used if no other singleton mode is specified during registration.
+        ///
+        /// Auto resolved services will always use the `autoResolveSingletonMode` variable.
+        /// </summary>
+        [SerializeField] private SingletonMode defaultSingletonMode = SingletonMode.Singleton;
 
         /// <summary>
         /// All the default Mono configurators which will be loaded when the container is initialized.
@@ -232,7 +240,8 @@ namespace TheRealIronDuck.Ducktion
         /// <typeparam name="TKey">The type which gets registered</typeparam>
         /// <typeparam name="TService">The concrete implementation type</typeparam>
         /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public ServiceDefinition Register<TKey, TService>() where TService : TKey => Register(typeof(TKey), typeof(TService));
+        public ServiceDefinition Register<TKey, TService>() where TService : TKey =>
+            Register(typeof(TKey), typeof(TService));
 
         /// <summary>
         /// Register a new service and its instance. The service type is used as the key and the concrete implementation.
@@ -340,7 +349,8 @@ namespace TheRealIronDuck.Ducktion
         /// <typeparam name="TKey">The type which gets registered</typeparam>
         /// <typeparam name="TService">The concrete implementation type</typeparam>
         /// <exception cref="DependencyRegisterException">If the override fails, it will throw an error</exception>
-        public ServiceDefinition Override<TKey, TService>() where TService : TKey => Override(typeof(TKey), typeof(TService));
+        public ServiceDefinition Override<TKey, TService>() where TService : TKey =>
+            Override(typeof(TKey), typeof(TService));
 
         /// <summary>
         /// Override any registered service with a specific instance. The instance will be registered as a singleton
@@ -353,7 +363,7 @@ namespace TheRealIronDuck.Ducktion
         {
             var definition = Override(type, instance.GetType());
             definition.Instance = instance;
-            
+
             return definition;
         }
 
@@ -391,7 +401,7 @@ namespace TheRealIronDuck.Ducktion
             _services[keyType].Callback = callback;
 
             _logger.Log(LogLevel.Debug, $"Overridden service: {keyType} with callback");
-            
+
             return _services[keyType];
         }
 

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -38,6 +38,12 @@ namespace TheRealIronDuck.Ducktion
         /// is specified (null), which means that the container will use the default lazy mode.
         /// </summary>
         public LazyMode? LazyMode { get; private set; }
+        
+        /// <summary>
+        /// Specify if the service should be stored as a singleton or not. By default, no singleton
+        /// mode is specified (null), which means that the container will use the default singleton mode.
+        /// </summary>
+        public SingletonMode? SingletonMode { get; private set; }
 
         #endregion
 
@@ -71,8 +77,33 @@ namespace TheRealIronDuck.Ducktion
             LazyMode = lazyMode;
             return this;
         }
+        
+        /// <summary>
+        /// Mark this service as non singleton
+        /// </summary>
+        public ServiceDefinition NonSingleton() => SetSingletonMode(Enums.SingletonMode.NonSingleton);
 
+        /// <summary>
+        /// Mark this service as singleton
+        /// </summary>
+        public ServiceDefinition Singleton() => SetSingletonMode(Enums.SingletonMode.Singleton);
+
+        /// <summary>
+        /// Mark this service as non singleton. Alias for `NonSingleton`.
+        /// </summary>
+        public ServiceDefinition Transient() => SetSingletonMode(Enums.SingletonMode.NonSingleton);
+
+        /// <summary>
+        /// Set the singleton mode of this service.
+        /// </summary>
+        /// <param name="singletonMode">The new singleton mode</param>
+        public ServiceDefinition SetSingletonMode(SingletonMode singletonMode)
+        {
+            SingletonMode = singletonMode;
+
+            return this;
+        }
+        
         #endregion
-
     }
 }

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using JetBrains.Annotations;
 using TheRealIronDuck.Ducktion.Enums;
+using TheRealIronDuck.Ducktion.Exceptions;
 
 namespace TheRealIronDuck.Ducktion
 {
@@ -99,6 +100,14 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="singletonMode">The new singleton mode</param>
         public ServiceDefinition SetSingletonMode(SingletonMode singletonMode)
         {
+            if (Instance != null && singletonMode == Enums.SingletonMode.NonSingleton)
+            {
+                throw new DependencyRegisterException(
+                    ServiceType,
+                    "Cannot bind an instance as non singleton"
+                );
+            }
+            
             SingletonMode = singletonMode;
 
             return this;

--- a/Samples/01_BasicContainerUsage/01_BasicContainerUsage.unity
+++ b/Samples/01_BasicContainerUsage/01_BasicContainerUsage.unity
@@ -157,6 +157,8 @@ MonoBehaviour:
   logLevel: 1
   enableAutoResolve: 1
   autoResolveSingletonMode: 0
+  defaultLazyMode: 0
+  defaultSingletonMode: 0
   defaultConfigurators:
   - {fileID: 455467826}
 --- !u!4 &455467825

--- a/Tests/Editor/Container/SingletonTest.cs
+++ b/Tests/Editor/Container/SingletonTest.cs
@@ -18,5 +18,6 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             // We check if both services are the same
             Assert.AreSame(service1, service2);
         }
+        
     }
 }

--- a/Tests/Editor/Container/SingletonTest.cs
+++ b/Tests/Editor/Container/SingletonTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
 using TheRealIronDuck.Ducktion.Enums;
+using TheRealIronDuck.Ducktion.Exceptions;
 
 namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 {
@@ -11,11 +12,11 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             // We register any service
             container.Register<SimpleService>();
-            
+
             // We resolve the service twice
             var service1 = container.Resolve<SimpleService>();
             var service2 = container.Resolve<SimpleService>();
-            
+
             // We check if both services are the same
             Assert.AreSame(service1, service2);
         }
@@ -25,27 +26,27 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             // We register any service
             container.Register<SimpleService>().NonSingleton();
-            
+
             // We resolve the service twice
             var service1 = container.Resolve<SimpleService>();
             var service2 = container.Resolve<SimpleService>();
-            
+
             // We check if both services are NOT the same
             Assert.AreNotSame(service1, service2);
         }
-        
+
         [Test]
         public void ItCanChangeTheDefaultModeToNonSingleton()
         {
             container.Configure(newDefaultSingletonMode: SingletonMode.NonSingleton);
-            
+
             // We register any service
             container.Register<SimpleService>();
-            
+
             // We resolve the service twice
             var service1 = container.Resolve<SimpleService>();
             var service2 = container.Resolve<SimpleService>();
-            
+
             // We check if both services are NOT the same
             Assert.AreNotSame(service1, service2);
         }
@@ -55,29 +56,40 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             // We register any service
             container.Register<SimpleService>(() => new SimpleService()).NonSingleton();
-            
+
             // We resolve the service twice
             var service1 = container.Resolve<SimpleService>();
             var service2 = container.Resolve<SimpleService>();
-            
+
             // We check if both services are NOT the same
             Assert.AreNotSame(service1, service2);
         }
-        
+
         [Test]
         public void ItCanRegisterCallbackBasedServicesAsNonSingletonWithContainerDefaults()
         {
             container.Configure(newDefaultSingletonMode: SingletonMode.NonSingleton);
-            
+
             // We register any service
             container.Register<SimpleService>(() => new SimpleService());
-            
+
             // We resolve the service twice
             var service1 = container.Resolve<SimpleService>();
             var service2 = container.Resolve<SimpleService>();
-            
+
             // We check if both services are NOT the same
             Assert.AreNotSame(service1, service2);
+        }
+
+        [Test]
+        public void ItThrowsAnErrorIfAnInstanceBindIsNonSingleton()
+        {
+            var error = Assert.Throws<DependencyRegisterException>(() =>
+            {
+                container.Register<SimpleService>(new SimpleService()).NonSingleton();
+            });
+
+            Assert.That(error.Message, Does.Contain("Cannot bind an instance as non singleton"));
         }
     }
 }

--- a/Tests/Editor/Container/SingletonTest.cs
+++ b/Tests/Editor/Container/SingletonTest.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
+using TheRealIronDuck.Ducktion.Enums;
 
 namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 {
@@ -18,6 +19,65 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             // We check if both services are the same
             Assert.AreSame(service1, service2);
         }
+
+        [Test]
+        public void ItCanRegisterSomeServicesAsNonSingleton()
+        {
+            // We register any service
+            container.Register<SimpleService>().NonSingleton();
+            
+            // We resolve the service twice
+            var service1 = container.Resolve<SimpleService>();
+            var service2 = container.Resolve<SimpleService>();
+            
+            // We check if both services are NOT the same
+            Assert.AreNotSame(service1, service2);
+        }
         
+        [Test]
+        public void ItCanChangeTheDefaultModeToNonSingleton()
+        {
+            container.Configure(newDefaultSingletonMode: SingletonMode.NonSingleton);
+            
+            // We register any service
+            container.Register<SimpleService>();
+            
+            // We resolve the service twice
+            var service1 = container.Resolve<SimpleService>();
+            var service2 = container.Resolve<SimpleService>();
+            
+            // We check if both services are NOT the same
+            Assert.AreNotSame(service1, service2);
+        }
+
+        [Test]
+        public void ItCanRegisterCallbackBasedServicesAsNonSingleton()
+        {
+            // We register any service
+            container.Register<SimpleService>(() => new SimpleService()).NonSingleton();
+            
+            // We resolve the service twice
+            var service1 = container.Resolve<SimpleService>();
+            var service2 = container.Resolve<SimpleService>();
+            
+            // We check if both services are NOT the same
+            Assert.AreNotSame(service1, service2);
+        }
+        
+        [Test]
+        public void ItCanRegisterCallbackBasedServicesAsNonSingletonWithContainerDefaults()
+        {
+            container.Configure(newDefaultSingletonMode: SingletonMode.NonSingleton);
+            
+            // We register any service
+            container.Register<SimpleService>(() => new SimpleService());
+            
+            // We resolve the service twice
+            var service1 = container.Resolve<SimpleService>();
+            var service2 = container.Resolve<SimpleService>();
+            
+            // We check if both services are NOT the same
+            Assert.AreNotSame(service1, service2);
+        }
     }
 }

--- a/Tests/Editor/ServiceDefinitionTest.cs
+++ b/Tests/Editor/ServiceDefinitionTest.cs
@@ -12,6 +12,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
             var definition = container.Register<SimpleService>();
             Assert.That(definition.ServiceType, Is.EqualTo(typeof(SimpleService)));
             Assert.That(definition.LazyMode, Is.Null);
+            Assert.That(definition.SingletonMode, Is.Null);
             Assert.That(definition.Instance, Is.Null);
             Assert.That(definition.Callback, Is.Null);
         }
@@ -36,6 +37,33 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
             var definition = container.Register<SimpleService>();
             definition.NonLazy().Lazy();
             
+            Assert.That(definition.LazyMode, Is.EqualTo(Enums.LazyMode.Lazy));
+        }
+
+        [Test]
+        public void ItCanToggleTheSingletonMode()
+        {
+            var definition = container.Register<SimpleService>();
+            definition.NonSingleton();
+            Assert.That(definition.SingletonMode, Is.EqualTo(Enums.SingletonMode.NonSingleton));
+            
+            definition.Singleton();
+            Assert.That(definition.SingletonMode, Is.EqualTo(Enums.SingletonMode.Singleton));
+
+            definition.Transient();
+            Assert.That(definition.SingletonMode, Is.EqualTo(Enums.SingletonMode.NonSingleton));
+            
+            definition.SetSingletonMode(SingletonMode.Singleton);
+            Assert.That(definition.SingletonMode, Is.EqualTo(Enums.SingletonMode.Singleton));
+        }
+        
+        [Test]
+        public void ItCanFluentlyChangeTheSingletonMode()
+        {
+            var definition = container.Register<SimpleService>();
+            definition.Singleton().Lazy();
+            
+            Assert.That(definition.SingletonMode, Is.EqualTo(Enums.SingletonMode.Singleton));
             Assert.That(definition.LazyMode, Is.EqualTo(Enums.LazyMode.Lazy));
         }
     }


### PR DESCRIPTION
### Added
- Services can be transient or singleton
  - Transient services will always be resolved as a new instance
  - Added methods to service definition:
    - `SetSingletonMode(singletonMode)` to specify the singleton mode
    - `Singleton()` to mark a service as singleton (Alias for `SetSingletonMode(SingletonMode.Singleton)`)
    - `NonSingleton()` to mark a service as non-singleton (Alias for `SetSingletonMode(SingletonMode.NonSingleton)`)
    - `Transient()` as an alias for `NonSingleton()`