### PR TITLE
Rewrite instance and callback registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added method `Register<TKey, TService>` to register a service with a specific implementation
   - Added method `Register(Type)` to register a simple service
   - Added method `Register(KeyType, ServiceType)` to register a service with a specific implementation
-  - Added method `Register<T>(Callback)` to register a type with a callback
-  - Added method `Register(Type, Callback)` to register a type with a callback
   - Added method `Override<TKey, TService>` to override any service with a specific implementation
   - Added method `Override(KeyType, ServiceType)` to override any service with a specific implementation
   - Added method `Override<TKey>` to override any service configurations, like singleton mode
   - Added method `Override(KeyType)` to override any service configurations, like singleton mode
-  - Added method `Override<T>(Callback)` to override any service with a specific callback
-  - Added method `Override(Type, Callback)` to override any service with a specific callback
   - Added method `Resolve<T>` to resolve a service
   - Added method `Resolve(Type)` to resolve a service
   - Added method `ResolveDependencies(Instance)` to resolve all dependencies with the `[Resolve]`attribute
@@ -46,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Services can register the singleton instances directly
   - Added method to service definition:
     - `SetInstance(instance)` to specify the singleton instance
+- Service can register a callback resolve function directly
+  - This clears the existing singleton instance as well
+  - Added method to service definition:
+    - `SetCallback(callback)` to specify the resolve function
 - Services can have IDs to be registered multiple times
   - The id can be specified in the registration methods
   - By default every service is registered without an id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added method `Register<TKey, TService>` to register a service with a specific implementation
   - Added method `Register(Type)` to register a simple service
   - Added method `Register(KeyType, ServiceType)` to register a service with a specific implementation
-  - Added method `Register<T>(Instance)` to register a type with a singleton instance
-  - Added method `Register(Type, Instance)` to register a type with a singleton instance
   - Added method `Register<T>(Callback)` to register a type with a callback
   - Added method `Register(Type, Callback)` to register a type with a callback
   - Added method `Override<TKey, TService>` to override any service with a specific implementation
   - Added method `Override(KeyType, ServiceType)` to override any service with a specific implementation
-  - Added method `Override<T>(Instance)` to override any service with a specific singleton instance
-  - Added method `Override(Type, Instance)` to override any service with a specific singleton instance
+  - Added method `Override<TKey>` to override any service configurations, like singleton mode
+  - Added method `Override(KeyType)` to override any service configurations, like singleton mode
   - Added method `Override<T>(Callback)` to override any service with a specific callback
   - Added method `Override(Type, Callback)` to override any service with a specific callback
   - Added method `Resolve<T>` to resolve a service
@@ -45,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `Singleton()` to mark a service as singleton (Alias for `SetSingletonMode(SingletonMode.Singleton)`)
     - `NonSingleton()` to mark a service as non-singleton (Alias for `SetSingletonMode(SingletonMode.NonSingleton)`)
     - `Transient()` as an alias for `NonSingleton()`
+- Services can register the singleton instances directly
+  - Added method to service definition:
+    - `SetInstance(instance)` to specify the singleton instance
 - Services can have IDs to be registered multiple times
   - The id can be specified in the registration methods
   - By default every service is registered without an id

--- a/Runtime/DiContainer.cs
+++ b/Runtime/DiContainer.cs
@@ -308,42 +308,6 @@ namespace TheRealIronDuck.Ducktion
         public ServiceDefinition Register<TKey, TService>([CanBeNull] string id = null) where TService : TKey =>
             Register(typeof(TKey), typeof(TService), id);
 
-        /// <summary>
-        /// Register a callback which gets called on resolve. This is useful if you want to resolve
-        /// a service which requires some parameters. The callback will be called on resolve and
-        /// be stored as a singleton.
-        /// more information.
-        /// </summary>
-        /// <param name="type">The type which should be registered</param>
-        /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
-        /// <param name="id">The id of the service</param>
-        /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public ServiceDefinition Register<T>(Type type, Func<T> callback, [CanBeNull] string id = null)
-        {
-            var serviceType = callback.Method.ReturnType.IsAbstract ? typeof(object) : type;
-            var definition = Register(type, serviceType, id);
-            definition.Callback = () => callback();
-
-            return definition;
-        }
-
-        /// <summary>
-        /// Register a callback which gets called on resolve. This is useful if you want to resolve
-        /// a service which requires some parameters. The callback will be called on resolve and
-        /// be stored as a singleton.
-        /// more information.
-        ///
-        /// Since the definition requires a Func(object), we can't simply pass the callback
-        /// directly. Instead we wrap the callback into another callback. Quite hacky, but
-        /// it is what it is.
-        /// </summary>
-        /// <typeparam name="T">The type which should be registered</typeparam>
-        /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
-        /// <param name="id">The id of the service</param>
-        /// <exception cref="DependencyRegisterException">If the registration fails, it will throw an error</exception>
-        public ServiceDefinition Register<T>(Func<T> callback, [CanBeNull] string id = null) =>
-            Register(typeof(T), callback, id);
-
         #endregion
 
         #region OVERRIDDING SERVICES
@@ -434,50 +398,6 @@ namespace TheRealIronDuck.Ducktion
         /// <param name="id">The id of the service</param>
         /// <exception cref="DependencyRegisterException">If the service doesn't exists, it will throw an error</exception>
         public ServiceDefinition Override<TKey>([CanBeNull] string id = null) => Override(typeof(TKey), id);
-
-        /// <summary>
-        /// Override a service with a callback which gets called on resolve. This is useful if you
-        /// want to resolve a service which requires some parameters. The callback will be called on
-        /// resolve and be stored as a singleton.
-        /// for more information.
-        /// </summary>
-        /// <param name="keyType">The type which gets registered</param>
-        /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
-        /// <param name="id">The id of the service</param>
-        /// <exception cref="DependencyRegisterException">If the override fails, it will throw an error</exception>
-        public ServiceDefinition Override(Type keyType, Func<object> callback, [CanBeNull] string id = null)
-        {
-            var key = new Tuple<string, Type>(id, keyType);
-            if (!_services.ContainsKey(key))
-            {
-                _logger.Log(LogLevel.Error, $"Service {keyType} is not registered");
-
-                throw new DependencyRegisterException(
-                    keyType,
-                    "Service is not registered. Use `register` to register the service"
-                );
-            }
-
-            _services[key].SetInstance(null);
-            _services[key].Callback = callback;
-
-            _logger.Log(LogLevel.Debug, $"Overridden service: {keyType} with callback");
-
-            return _services[key];
-        }
-
-        /// <summary>
-        /// Override a service with a callback which gets called on resolve. This is useful if you
-        /// want to resolve a service which requires some parameters. The callback will be called on
-        /// resolve and be stored as a singleton.
-        /// for more information.
-        /// </summary>
-        /// <typeparam name="T">The type which gets registered</typeparam>
-        /// <param name="callback">The callback which gets called on resolve. Must return an instance</param>
-        /// <param name="id">The id of the service</param>
-        /// <exception cref="DependencyRegisterException">If the override fails, it will throw an error</exception>
-        public ServiceDefinition Override<T>(Func<T> callback, [CanBeNull] string id = null) =>
-            Override(typeof(T), () => callback(), id);
 
         #endregion
 

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -30,21 +30,23 @@ namespace TheRealIronDuck.Ducktion
         ///
         /// Can only be set by the container.
         /// </summary>
-        [CanBeNull] public object Instance { get; internal set; }
+        [CanBeNull]
+        public object Instance { get; private set; }
 
         /// <summary>
         /// The given callback to resolve the service. Can be null if no callback was given.
         ///
         /// Can only be set by the container.
         /// </summary>
-        [CanBeNull] public Func<object> Callback { get; internal set; }
+        [CanBeNull]
+        public Func<object> Callback { get; internal set; }
 
         /// <summary>
         /// Specify if the service should be resolved lazily or not. By default, no lazy mode
         /// is specified (null), which means that the container will use the default lazy mode.
         /// </summary>
         public LazyMode? LazyMode { get; private set; }
-        
+
         /// <summary>
         /// Specify if the service should be stored as a singleton or not. By default, no singleton
         /// mode is specified (null), which means that the container will use the default singleton mode.
@@ -74,7 +76,7 @@ namespace TheRealIronDuck.Ducktion
             LazyMode = lazyMode;
             return this;
         }
-        
+
         /// <summary>
         /// Mark this service as non lazy.
         /// </summary>
@@ -86,7 +88,7 @@ namespace TheRealIronDuck.Ducktion
         public ServiceDefinition Lazy() => SetLazyMode(Enums.LazyMode.Lazy);
 
         #endregion
-        
+
         #region SINGLETON CONFIGURATION
 
         /// <summary>
@@ -122,17 +124,26 @@ namespace TheRealIronDuck.Ducktion
         /// Mark this service as non singleton. Alias for `NonSingleton`.
         /// </summary>
         public ServiceDefinition Transient() => SetSingletonMode(Enums.SingletonMode.NonSingleton);
-        
+
         #endregion
 
         #region INSTANCE CONFIGURATION
 
-        public void SetInstance(object instance)
+        public ServiceDefinition SetInstance([CanBeNull] object instance)
         {
+            if (!ServiceType.IsInstanceOfType(instance) && instance != null)
+            {
+                throw new DependencyRegisterException(
+                    ServiceType,
+                    $"Service {instance.GetType()} does not extend {ServiceType}"
+                );
+            }
+
             Instance = instance;
+
+            return this;
         }
 
         #endregion
-        
     }
 }

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -124,5 +124,15 @@ namespace TheRealIronDuck.Ducktion
         public ServiceDefinition Transient() => SetSingletonMode(Enums.SingletonMode.NonSingleton);
         
         #endregion
+
+        #region INSTANCE CONFIGURATION
+
+        public void SetInstance(object instance)
+        {
+            Instance = instance;
+        }
+
+        #endregion
+        
     }
 }

--- a/Runtime/ServiceDefinition.cs
+++ b/Runtime/ServiceDefinition.cs
@@ -39,7 +39,7 @@ namespace TheRealIronDuck.Ducktion
         /// Can only be set by the container.
         /// </summary>
         [CanBeNull]
-        public Func<object> Callback { get; internal set; }
+        public Func<object> Callback { get; private set; }
 
         /// <summary>
         /// Specify if the service should be resolved lazily or not. By default, no lazy mode
@@ -140,6 +140,18 @@ namespace TheRealIronDuck.Ducktion
             }
 
             Instance = instance;
+
+            return this;
+        }
+
+        #endregion
+
+        #region CALLBACK CONFIGURATION
+
+        public ServiceDefinition SetCallback(Func<object> callback)
+        {
+            Instance = null;
+            Callback = callback;
 
             return this;
         }

--- a/Tests/Editor/Container/CallbackBindingTest.cs
+++ b/Tests/Editor/Container/CallbackBindingTest.cs
@@ -17,7 +17,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
                 return new ScalarService(123);
             });
 
-            container.Register<ScalarService>(action);
+            container.Register<ScalarService>().SetCallback(action);
             Assert.IsFalse(called);
 
             var service = container.Resolve<ScalarService>();
@@ -36,7 +36,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
                 return new ScalarService(123);
             });
 
-            container.Register(typeof(ScalarService), action);
+            container.Register(typeof(ScalarService)).SetCallback(action);
             Assert.IsFalse(called);
 
             var service = container.Resolve<ScalarService>();
@@ -51,7 +51,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 
             container.Register<ScalarService>();
 
-            container.Override<ScalarService>(action);
+            container.Override<ScalarService>().SetCallback(action);
 
             var service = container.Resolve<ScalarService>();
             Assert.AreEqual(123, service.Value);
@@ -65,7 +65,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             var existing = new ScalarService(42);
             container.Register<ScalarService>().SetInstance(existing);
 
-            container.Override<ScalarService>(action);
+            container.Override<ScalarService>().SetCallback(action);
 
             var service = container.Resolve<ScalarService>();
             Assert.AreEqual(123, service.Value);
@@ -78,34 +78,10 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 
             container.Register<ScalarService>();
 
-            container.Override(typeof(ScalarService), action);
+            container.Override(typeof(ScalarService)).SetCallback(action);
 
             var service = container.Resolve<ScalarService>();
             Assert.AreEqual(123, service.Value);
-        }
-
-        [Test]
-        public void ItCanRegisterCallbacksWithAbstractServicesOrInterfaces()
-        {
-            var simpleImplementation = new SimpleService();
-            var action = new Func<ISimpleInterface>(() => simpleImplementation);
-
-            container.Register<ISimpleInterface>(action);
-
-            var service = container.Resolve<ISimpleInterface>();
-            Assert.AreSame(simpleImplementation, service);
-        }
-
-        [Test]
-        public void ItCanRegisterCallbacksWithAbstractServicesOrInterfacesUsingTheTypeParameter()
-        {
-            var simpleImplementation = new SimpleService();
-            var action = new Func<ISimpleInterface>(() => simpleImplementation);
-
-            container.Register(typeof(ISimpleInterface), action);
-
-            var service = container.Resolve<ISimpleInterface>();
-            Assert.AreSame(simpleImplementation, service);
         }
         
         [Test]
@@ -120,7 +96,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
                 return service;
             });
 
-            container.Register<ScalarService>(action);
+            container.Register<ScalarService>().SetCallback(action);
 
             var service1 = container.Resolve<ScalarService>();
             Assert.AreEqual(1, calledCount);

--- a/Tests/Editor/Container/CallbackBindingTest.cs
+++ b/Tests/Editor/Container/CallbackBindingTest.cs
@@ -63,7 +63,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             var action = new Func<ScalarService>(() => new ScalarService(123));
 
             var existing = new ScalarService(42);
-            container.Register<ScalarService>(existing);
+            container.Register<ScalarService>().SetInstance(existing);
 
             container.Override<ScalarService>(action);
 

--- a/Tests/Editor/Container/IdTest.cs
+++ b/Tests/Editor/Container/IdTest.cs
@@ -44,18 +44,12 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 
             container.Register<ISimpleInterface, SimpleService>("id4");
             Assert.That(container.Resolve<ISimpleInterface>("id4"), Is.InstanceOf<SimpleService>());
-
-            container.Register(typeof(ISimpleInterface), new SimpleService(), "id5");
+            
+            container.Register(typeof(ISimpleInterface), new Func<ISimpleInterface>(() => new SimpleService()), "id5");
             Assert.That(container.Resolve<ISimpleInterface>("id5"), Is.InstanceOf<SimpleService>());
 
-            container.Register<ISimpleInterface>(new SimpleService(), "id6");
+            container.Register<ISimpleInterface>(new Func<ISimpleInterface>(() => new SimpleService()), "id6");
             Assert.That(container.Resolve<ISimpleInterface>("id6"), Is.InstanceOf<SimpleService>());
-
-            container.Register(typeof(ISimpleInterface), new Func<ISimpleInterface>(() => new SimpleService()), "id7");
-            Assert.That(container.Resolve<ISimpleInterface>("id7"), Is.InstanceOf<SimpleService>());
-
-            container.Register<ISimpleInterface>(new Func<ISimpleInterface>(() => new SimpleService()), "id8");
-            Assert.That(container.Resolve<ISimpleInterface>("id8"), Is.InstanceOf<SimpleService>());
         }
 
         [Test]
@@ -79,21 +73,25 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             container.Override<ISimpleInterface, SecondSimpleService>(id: "id2");
             Assert.That(container.Resolve<ISimpleInterface>("id2"), Is.InstanceOf<SecondSimpleService>());
 
+            var specific = new SimpleService();
             container.Register<ISimpleInterface, SimpleService>(id: "id3");
-            container.Override(typeof(ISimpleInterface), new SecondSimpleService(), id: "id3");
-            Assert.That(container.Resolve<ISimpleInterface>("id3"), Is.InstanceOf<SecondSimpleService>());
-
-            container.Register<ISimpleInterface, SimpleService>(id: "id4");
-            container.Override<ISimpleInterface>(new SecondSimpleService(), id: "id4");
-            Assert.That(container.Resolve<ISimpleInterface>("id4"), Is.InstanceOf<SecondSimpleService>());
-
-            container.Register<ISimpleInterface, SimpleService>(id: "id5");
-            container.Override(typeof(ISimpleInterface), () => new SecondSimpleService(), id: "id5");
-            Assert.That(container.Resolve<ISimpleInterface>("id5"), Is.InstanceOf<SecondSimpleService>());
+            container.Override(typeof(ISimpleInterface), () => specific, id: "id3");
+            Assert.That(container.Resolve<ISimpleInterface>("id3"), Is.SameAs(specific));
             
+            var specific2 = new SimpleService();
+            container.Register<ISimpleInterface, SimpleService>(id: "id4");
+            container.Override<ISimpleInterface>(() => specific2, id: "id4");
+            Assert.That(container.Resolve<ISimpleInterface>("id4"), Is.SameAs(specific2));
+
+            var specific3 = new SimpleService();
+            container.Register<ISimpleInterface, SimpleService>(id: "id5");
+            container.Override(typeof(ISimpleInterface), id: "id5").SetInstance(specific3);
+            Assert.That(container.Resolve<ISimpleInterface>("id5"), Is.SameAs(specific3));
+            
+            var specific4 = new SimpleService();
             container.Register<ISimpleInterface, SimpleService>(id: "id6");
-            container.Override<ISimpleInterface>(() => new SecondSimpleService(), id: "id6");
-            Assert.That(container.Resolve<ISimpleInterface>("id6"), Is.InstanceOf<SecondSimpleService>());
+            container.Override<ISimpleInterface>(id: "id6").SetInstance(specific4);
+            Assert.That(container.Resolve<ISimpleInterface>("id6"), Is.SameAs(specific4));
         }
     }
 }

--- a/Tests/Editor/Container/IdTest.cs
+++ b/Tests/Editor/Container/IdTest.cs
@@ -44,12 +44,6 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 
             container.Register<ISimpleInterface, SimpleService>("id4");
             Assert.That(container.Resolve<ISimpleInterface>("id4"), Is.InstanceOf<SimpleService>());
-            
-            container.Register(typeof(ISimpleInterface), new Func<ISimpleInterface>(() => new SimpleService()), "id5");
-            Assert.That(container.Resolve<ISimpleInterface>("id5"), Is.InstanceOf<SimpleService>());
-
-            container.Register<ISimpleInterface>(new Func<ISimpleInterface>(() => new SimpleService()), "id6");
-            Assert.That(container.Resolve<ISimpleInterface>("id6"), Is.InstanceOf<SimpleService>());
         }
 
         [Test]
@@ -73,25 +67,15 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             container.Override<ISimpleInterface, SecondSimpleService>(id: "id2");
             Assert.That(container.Resolve<ISimpleInterface>("id2"), Is.InstanceOf<SecondSimpleService>());
 
-            var specific = new SimpleService();
+            var specific1 = new SimpleService();
             container.Register<ISimpleInterface, SimpleService>(id: "id3");
-            container.Override(typeof(ISimpleInterface), () => specific, id: "id3");
-            Assert.That(container.Resolve<ISimpleInterface>("id3"), Is.SameAs(specific));
+            container.Override(typeof(ISimpleInterface), id: "id3").SetInstance(specific1);
+            Assert.That(container.Resolve<ISimpleInterface>("id3"), Is.SameAs(specific1));
             
             var specific2 = new SimpleService();
             container.Register<ISimpleInterface, SimpleService>(id: "id4");
-            container.Override<ISimpleInterface>(() => specific2, id: "id4");
+            container.Override<ISimpleInterface>(id: "id4").SetInstance(specific2);
             Assert.That(container.Resolve<ISimpleInterface>("id4"), Is.SameAs(specific2));
-
-            var specific3 = new SimpleService();
-            container.Register<ISimpleInterface, SimpleService>(id: "id5");
-            container.Override(typeof(ISimpleInterface), id: "id5").SetInstance(specific3);
-            Assert.That(container.Resolve<ISimpleInterface>("id5"), Is.SameAs(specific3));
-            
-            var specific4 = new SimpleService();
-            container.Register<ISimpleInterface, SimpleService>(id: "id6");
-            container.Override<ISimpleInterface>(id: "id6").SetInstance(specific4);
-            Assert.That(container.Resolve<ISimpleInterface>("id6"), Is.SameAs(specific4));
         }
     }
 }

--- a/Tests/Editor/Container/InstanceBindingTest.cs
+++ b/Tests/Editor/Container/InstanceBindingTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System;
+using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
 using TheRealIronDuck.Ducktion.Exceptions;
 using UnityEngine;
@@ -12,17 +13,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             var service = new SimpleService();
 
-            container.Register<ISimpleInterface>(service);
-
-            Assert.AreSame(service, container.Resolve<ISimpleInterface>());
-        }
-
-        [Test]
-        public void ItCanRegisterSpecificInstancesUsingTypeParameter()
-        {
-            var service = new SimpleService();
-
-            container.Register(typeof(ISimpleInterface), service);
+            container.Register<ISimpleInterface, SimpleService>().SetInstance(service);
 
             Assert.AreSame(service, container.Resolve<ISimpleInterface>());
         }
@@ -33,20 +24,20 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             var service = new AnotherService();
 
             var error = Assert.Throws<DependencyRegisterException>(
-                () => container.Register(typeof(ISimpleInterface), service)
+                () => container.Register(typeof(ISimpleInterface), typeof(SimpleService)).SetInstance(service)
             );
 
             Assert.That(error.Message, Does.Contain(
-                $"Service {typeof(AnotherService)} does not extend {typeof(ISimpleInterface)}"
+                $"Service {typeof(AnotherService)} does not extend {typeof(SimpleService)}"
             ));
         }
-        
+
         [Test]
         public void ItAllowsToRegisterForExampleGameObjectsWhichHaveMultipleConstructors()
         {
             var gObj = new GameObject("Hello World!");
-            container.Register<GameObject>(gObj);
-            
+            container.Register<GameObject>().SetInstance(gObj);
+
             Assert.AreSame(gObj, container.Resolve<GameObject>());
         }
 
@@ -54,14 +45,14 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         public void ItCanOverrideAServiceWithASpecificInstance()
         {
             container.Register<SimpleService>();
-            
+
             var old = container.Resolve<SimpleService>();
-            
+
             var service = new SimpleService();
-            container.Override<SimpleService>(service);
-            
+            container.Override<SimpleService>().SetInstance(service);
+
             var current = container.Resolve<SimpleService>();
-            
+
             Assert.AreSame(service, current);
             Assert.AreNotSame(old, current);
         }
@@ -71,12 +62,13 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             var serviceA = new SimpleService();
             var serviceB = new SimpleService();
-            
-            container.Register<SimpleService>(serviceA);
-            container.Override<SimpleService>(serviceB);
-            
+
+            container.Register<SimpleService>().SetInstance(serviceA);
+
+            container.Override<SimpleService>().SetInstance(serviceB);
+
             var current = container.Resolve<SimpleService>();
-            
+
             Assert.AreSame(serviceB, current);
         }
 
@@ -84,14 +76,15 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         public void ItCanOverrideUsingTypeParameters()
         {
             container.Register<SimpleService>();
-            
+
             var old = container.Resolve<SimpleService>();
-            
+
             var service = new SimpleService();
-            container.Override(typeof(SimpleService), service);
-            
+
+            container.Override(typeof(SimpleService)).SetInstance(service);
+
             var current = container.Resolve<SimpleService>();
-            
+
             Assert.AreSame(service, current);
             Assert.AreNotSame(old, current);
         }

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -87,17 +87,6 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
                 container.Register<SimpleBaseClass, SimpleService>(),
                 Is.InstanceOf<ServiceDefinition>()
             );
-
-            Assert.That(
-                container.Register<SimpleService>(new SimpleService()),
-                Is.InstanceOf<ServiceDefinition>()
-            );
-
-            Assert.That(
-                container.Register(typeof(SimpleServiceWithDependency),
-                    new SimpleServiceWithDependency(new AnotherService())),
-                Is.InstanceOf<ServiceDefinition>()
-            );
             
             container.Clear();
             
@@ -137,16 +126,6 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             
             Assert.That(
                 container.Override<ISimpleInterface, SimpleService>(),
-                Is.InstanceOf<ServiceDefinition>()
-            );
-            
-            Assert.That(
-                container.Override(typeof(ISimpleInterface), new SimpleService()),
-                Is.InstanceOf<ServiceDefinition>()
-            );
-            
-            Assert.That(
-                container.Override<ISimpleInterface>(new SimpleService()),
                 Is.InstanceOf<ServiceDefinition>()
             );
             

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -91,12 +91,12 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             container.Clear();
             
             Assert.That(
-                container.Register(typeof(SimpleService), () => new SimpleService()),
+                container.Register(typeof(SimpleService)).SetCallback(() => new SimpleService()),
                 Is.InstanceOf<ServiceDefinition>()
             );
             
             Assert.That(
-                container.Register<ISimpleInterface>(() => new SimpleService()),
+                container.Register<ISimpleInterface, SimpleService>().SetCallback(() => new SimpleService()),
                 Is.InstanceOf<ServiceDefinition>()
             );
         }
@@ -130,12 +130,12 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             );
             
             Assert.That(
-                container.Override(typeof(ISimpleInterface), () => new SimpleService()),
+                container.Override(typeof(ISimpleInterface)).SetCallback(() => new SimpleService()),
                 Is.InstanceOf<ServiceDefinition>()
             );
             
             Assert.That(
-                container.Override<ISimpleInterface>(() => new SimpleService()),
+                container.Override<ISimpleInterface>().SetCallback(() => new SimpleService()),
                 Is.InstanceOf<ServiceDefinition>()
             );
         }

--- a/Tests/Editor/Container/OverrideTest.cs
+++ b/Tests/Editor/Container/OverrideTest.cs
@@ -94,5 +94,31 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
                 $"Service {typeof(AnotherService)} does not extend {typeof(ISimpleInterface)}"
             ));
         }
+
+        [Test]
+        public void ItCanUseOverrideToOnlySetServiceDefinitionStuff()
+        {
+            var instance = new SimpleService();
+            
+            container.Register<ISimpleInterface, SimpleService>();
+
+            container.Override<ISimpleInterface>().SetInstance(instance);
+            
+            var service = container.Resolve<ISimpleInterface>();
+            Assert.AreSame(instance, service);
+        }
+        
+        [Test]
+        public void ItCanUseOverrideToOnlySetServiceDefinitionStuffUsingATypeParameter()
+        {
+            var instance = new SimpleService();
+            
+            container.Register<ISimpleInterface, SimpleService>();
+
+            container.Override(typeof(ISimpleInterface)).SetInstance(instance);
+            
+            var service = container.Resolve<ISimpleInterface>();
+            Assert.AreSame(instance, service);
+        }
     }
 }

--- a/Tests/Editor/Container/SingletonTest.cs
+++ b/Tests/Editor/Container/SingletonTest.cs
@@ -86,7 +86,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             var error = Assert.Throws<DependencyRegisterException>(() =>
             {
-                container.Register<SimpleService>(new SimpleService()).NonSingleton();
+                container.Register<SimpleService>().SetInstance(new SimpleService()).NonSingleton();
             });
 
             Assert.That(error.Message, Does.Contain("Cannot bind an instance as non singleton"));

--- a/Tests/Editor/Container/SingletonTest.cs
+++ b/Tests/Editor/Container/SingletonTest.cs
@@ -55,7 +55,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         public void ItCanRegisterCallbackBasedServicesAsNonSingleton()
         {
             // We register any service
-            container.Register<SimpleService>(() => new SimpleService()).NonSingleton();
+            container.Register<SimpleService>().SetCallback(() => new SimpleService()).NonSingleton();
 
             // We resolve the service twice
             var service1 = container.Resolve<SimpleService>();
@@ -71,7 +71,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             container.Configure(newDefaultSingletonMode: SingletonMode.NonSingleton);
 
             // We register any service
-            container.Register<SimpleService>(() => new SimpleService());
+            container.Register<SimpleService>().SetCallback(() => new SimpleService());
 
             // We resolve the service twice
             var service1 = container.Resolve<SimpleService>();

--- a/Tests/Editor/ResolveAttribute/AutomaticResolveAttributeTest.cs
+++ b/Tests/Editor/ResolveAttribute/AutomaticResolveAttributeTest.cs
@@ -106,11 +106,11 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.ResolveAttribute
             var another2 = new AnotherService();
             
             // Register registered services
-            container.Register<SimpleService>(simple1);
-            container.Register<SimpleService>(simple2, "simple");
+            container.Register<SimpleService>().SetInstance(simple1);
+            container.Register<SimpleService>("simple").SetInstance(simple2);
             
-            container.Register<AnotherService>(another1);
-            container.Register<AnotherService>(another2, "another");
+            container.Register<AnotherService>().SetInstance(another1);
+            container.Register<AnotherService>("another").SetInstance(another2);
             
             container.Register<ServiceWithIdFieldsAndProperties>();
             
@@ -129,8 +129,8 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.ResolveAttribute
             var simple2 = new SimpleService();
             
             // Register registered services
-            container.Register<SimpleService>(simple1);
-            container.Register<SimpleService>(simple2, "simple");
+            container.Register<SimpleService>().SetInstance(simple1);
+            container.Register<SimpleService>("simple").SetInstance(simple2);
             
             container.Register<AnotherService>();
             
@@ -151,8 +151,8 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.ResolveAttribute
             var simple2 = new SimpleService();
             
             // Register registered services
-            container.Register<SimpleService>(simple1);
-            container.Register<SimpleService>(simple2, "simple");
+            container.Register<SimpleService>().SetInstance(simple1);
+            container.Register<SimpleService>("simple").SetInstance(simple2);
             
             container.Register<AnotherService>();
             

--- a/Tests/Editor/ServiceDefinitionTest.cs
+++ b/Tests/Editor/ServiceDefinitionTest.cs
@@ -91,5 +91,29 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
             Assert.That(definition.Instance, Is.SameAs(instance));
             Assert.That(definition.LazyMode, Is.EqualTo(LazyMode.Lazy));
         }
+        
+        [Test]
+        public void ItCanSetTheCallback()
+        {
+            var instance = new SimpleService();
+            
+            var definition = container.Register<SimpleService>();
+            definition.SetCallback(() => instance);
+            Assert.That(definition.Callback?.Invoke(), Is.SameAs(instance));
+            
+            definition.SetCallback(null);
+            Assert.That(definition.Callback, Is.Null);
+        }
+        
+        [Test]
+        public void ItCanFluentlySetTheCallback()
+        {
+            var instance = new SimpleService();
+            
+            var definition = container.Register<SimpleService>();
+            definition.SetCallback(() => instance).Lazy();
+            Assert.That(definition.Callback?.Invoke(), Is.SameAs(instance));
+            Assert.That(definition.LazyMode, Is.EqualTo(LazyMode.Lazy));
+        }
     }
 }

--- a/Tests/Editor/ServiceDefinitionTest.cs
+++ b/Tests/Editor/ServiceDefinitionTest.cs
@@ -81,6 +81,15 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
             Assert.That(definition.Instance, Is.Null);
         }
         
-        // TODO: Fluent setinstance
+        [Test]
+        public void ItCanFluentlySetTheInstance()
+        {
+            var instance = new SimpleService();
+            
+            var definition = container.Register<SimpleService>();
+            definition.SetInstance(instance).Lazy();
+            Assert.That(definition.Instance, Is.SameAs(instance));
+            Assert.That(definition.LazyMode, Is.EqualTo(LazyMode.Lazy));
+        }
     }
 }

--- a/Tests/Editor/ServiceDefinitionTest.cs
+++ b/Tests/Editor/ServiceDefinitionTest.cs
@@ -67,5 +67,20 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
             Assert.That(definition.SingletonMode, Is.EqualTo(Enums.SingletonMode.Singleton));
             Assert.That(definition.LazyMode, Is.EqualTo(Enums.LazyMode.Lazy));
         }
+
+        [Test]
+        public void ItCanSetTheInstance()
+        {
+            var instance = new SimpleService();
+            
+            var definition = container.Register<SimpleService>();
+            definition.SetInstance(instance);
+            Assert.That(definition.Instance, Is.SameAs(instance));
+            
+            definition.SetInstance(null);
+            Assert.That(definition.Instance, Is.Null);
+        }
+        
+        // TODO: Fluent setinstance
     }
 }

--- a/Tests/Editor/Stubs/ExampleConfigurator.cs
+++ b/Tests/Editor/Stubs/ExampleConfigurator.cs
@@ -9,7 +9,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs
         public void Register(DiContainer container)
         {
             container.Register<ISimpleInterface, SimpleService>();
-            container.Register<ScalarService>(new ScalarService(123));
+            container.Register<ScalarService>().SetInstance(new ScalarService(123));
             container.Register<AnotherService>(() => new AnotherService());
 
             Called = true;

--- a/Tests/Editor/Stubs/ExampleConfigurator.cs
+++ b/Tests/Editor/Stubs/ExampleConfigurator.cs
@@ -10,7 +10,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs
         {
             container.Register<ISimpleInterface, SimpleService>();
             container.Register<ScalarService>().SetInstance(new ScalarService(123));
-            container.Register<AnotherService>(() => new AnotherService());
+            container.Register<AnotherService>().SetCallback(() => new AnotherService());
 
             Called = true;
         }

--- a/Tests/Runtime/Stubs/ExampleMonoConfigurator.cs
+++ b/Tests/Runtime/Stubs/ExampleMonoConfigurator.cs
@@ -10,7 +10,7 @@ namespace TheRealIronDuck.Ducktion.Tests.Stubs
         public override void Register(DiContainer container)
         {
             container.Register<ISimpleInterface, SimpleService>();
-            container.Register<ScalarService>(new ScalarService(123));
+            container.Register<ScalarService>().SetInstance(new ScalarService(123));
             container.Register<AnotherService>(() => new AnotherService());
 
             called = true;

--- a/Tests/Runtime/Stubs/ExampleMonoConfigurator.cs
+++ b/Tests/Runtime/Stubs/ExampleMonoConfigurator.cs
@@ -11,7 +11,7 @@ namespace TheRealIronDuck.Ducktion.Tests.Stubs
         {
             container.Register<ISimpleInterface, SimpleService>();
             container.Register<ScalarService>().SetInstance(new ScalarService(123));
-            container.Register<AnotherService>(() => new AnotherService());
+            container.Register<AnotherService>().SetCallback(() => new AnotherService());
 
             called = true;
         }


### PR DESCRIPTION
### Added
- Services can register the singleton instances directly
  - Added method to service definition:
    - `SetInstance(instance)` to specify the singleton instance
- Service can register a callback resolve function directly
  - This clears the existing singleton instance as well
  - Added method to service definition:
    - `SetCallback(callback)` to specify the resolve function

### Removed
- DIContainer
   - Removed method `Register<T>(Instance)` to register a type with a singleton instance
   - Removed method `Register(Type, Instance)` to register a type with a singleton instance
   - Removed method `Register<T>(Callback)` to register a type with a callback
   - Removed method `Register(Type, Callback)` to register a type with a callback
   - Removed method `Override<T>(Instance)` to override any service with a specific singleton instance
   - Removed method `Override(Type, Instance)` to override any service with a specific singleton instance
   - Removed method `Override<T>(Callback)` to override any service with a specific callback
   - Removed method `Override(Type, Callback)` to override any service with a specific callback