### PR TITLE
Add event bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Services can be registered in configurators
   - Either by using the `IDiConfigurator` interface and manually registering the configurator
   - Or by using the `MonoDiConfigurator` component and adding it to the containers inspector
+- Add simple event bus implementation
+  - This can be enabled in the Container configuration
+  - You can register event listeners for any events
+  - Events must implement the `IEvent` interface
 - Handle security methods and exceptions
   - When a service is abstract / interface / enum
   - When a service is already registered

--- a/Editor/DiContainerInspector.cs
+++ b/Editor/DiContainerInspector.cs
@@ -51,6 +51,7 @@ namespace TheRealIronDuck.Ducktion.Editor
         /// <summary>
         /// Render the box which contains the general options.
         /// - DontDestroyOnLoad
+        /// - EnableEventBus
         /// - LogLevel
         /// </summary>
         /// <returns>The general options box</returns>
@@ -58,6 +59,7 @@ namespace TheRealIronDuck.Ducktion.Editor
         {
             var generalOptions = CreateBox("General options");
             generalOptions.Add(new PropertyField(serializedObject.FindProperty("dontDestroyOnLoad")));
+            generalOptions.Add(new PropertyField(serializedObject.FindProperty("enableEventBus")));
             generalOptions.Add(new PropertyField(serializedObject.FindProperty("logLevel")));
             return generalOptions;
         }

--- a/Runtime/Events.meta
+++ b/Runtime/Events.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5a089e7d56bc4f208a8345f2657f7a1a
+timeCreated: 1700315571

--- a/Runtime/Events/EventBus.cs
+++ b/Runtime/Events/EventBus.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using TheRealIronDuck.Ducktion.Attributes;
+using TheRealIronDuck.Ducktion.Logging;
+
+namespace TheRealIronDuck.Ducktion.Events
+{
+    /// <summary>
+    /// This is a simple event bus implementation. It allows you to listen to events and fire them.
+    /// Events must implement the IEvent interface.
+    ///
+    /// The event bus can be enabled/disabled in the container configuration and fetched like any
+    /// service.
+    /// </summary>
+    public class EventBus
+    {
+        /// <summary>
+        /// The internal list of all registered event listeners. Events itself don't need to be registered
+        /// specifically, as they are registered when the first listener is added.
+        /// </summary>
+        private readonly Dictionary<Type, List<Delegate>> _eventListeners = new();
+
+        /// <summary>
+        /// The logger is injected by the container. It is used to log info messages if no listeners
+        /// were found for a specific event.
+        /// </summary>
+        [Resolve] private readonly DucktionLogger _logger;
+
+        /// <summary>
+        /// Register an event listener. The listener will be called when the event is fired and be
+        /// given the event as a parameter.
+        /// </summary>
+        /// <param name="action">The action that should run when the event is fired</param>
+        /// <typeparam name="TEvent">The event for which the listener is registered</typeparam>
+        public void Listen<TEvent>(Action<TEvent> action) where TEvent : IEvent
+        {
+            if (_eventListeners.TryGetValue(typeof(TEvent), out var listeners))
+            {
+                listeners.Add(action);
+                return;
+            }
+
+            _eventListeners.Add(typeof(TEvent), new List<Delegate> { action });
+        }
+        
+        /// <summary>
+        /// Forget a previously registered event listener. The listener will no longer be called when
+        /// the event is fired.
+        /// </summary>
+        /// <param name="action">The action to forget</param>
+        /// <typeparam name="TEvent">The event where the listener was registered</typeparam>
+        public void Forget<TEvent>(Action<TEvent> action) where TEvent : IEvent
+        {
+            if (!_eventListeners.TryGetValue(typeof(TEvent), out var listeners))
+            {
+                _logger.Log(
+                    LogLevel.Info,
+                    $"No event listeners found for event {typeof(TEvent)}"
+                );
+                return;
+            }
+
+            listeners.Remove(action);
+        }
+
+        /// <summary>
+        /// Fire an event. This will call all registered listeners for the event.
+        /// </summary>
+        /// <param name="event">The event which should be fired</param>
+        public void Fire(IEvent @event)
+        {
+            if (!_eventListeners.ContainsKey(@event.GetType()))
+            {
+                _logger.Log(
+                    LogLevel.Info,
+                    $"No event listeners found for event {@event.GetType()}"
+                );
+                return;
+            }
+
+            _eventListeners[@event.GetType()].ForEach(listener => listener.DynamicInvoke(@event));
+        }
+
+        /// <summary>
+        /// Clear all listeners for a specific event.
+        /// </summary>
+        /// <typeparam name="TEvent">The event which should be forgotten</typeparam>
+        public void Clear<TEvent>() where TEvent : IEvent
+        {
+            _eventListeners.Remove(typeof(TEvent));
+        }
+    }
+}

--- a/Runtime/Events/EventBus.cs.meta
+++ b/Runtime/Events/EventBus.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1832d1d7dc944be8a45a21ba2d48fc42
+timeCreated: 1700315591

--- a/Runtime/Events/EventBusConfigurator.cs
+++ b/Runtime/Events/EventBusConfigurator.cs
@@ -1,0 +1,21 @@
+using TheRealIronDuck.Ducktion.Configurators;
+
+namespace TheRealIronDuck.Ducktion.Events
+{
+    /// <summary>
+    /// This configurator registers any service which is required for the eventbus to function.
+    /// </summary>
+    public class EventBusConfigurator : IDiConfigurator
+    {
+        /// <summary>
+        /// In this method you may use the container to register your dependencies.
+        /// Please note that you should not use the container to resolve dependencies at
+        /// this stage, as it may not be fully configured yet.
+        /// </summary>
+        /// <param name="container">The dependency injection container</param>
+        public void Register(DiContainer container)
+        {
+            container.Register<EventBus>().Singleton().Lazy();
+        }
+    }
+}

--- a/Runtime/Events/EventBusConfigurator.cs.meta
+++ b/Runtime/Events/EventBusConfigurator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5386b8be31b14908a151b59606f6832b
+timeCreated: 1700316791

--- a/Runtime/Events/IEvent.cs
+++ b/Runtime/Events/IEvent.cs
@@ -1,0 +1,9 @@
+namespace TheRealIronDuck.Ducktion.Events
+{
+    /// <summary>
+    /// Any event must implement this interface.
+    /// </summary>
+    public interface IEvent
+    {
+    }
+}

--- a/Runtime/Events/IEvent.cs.meta
+++ b/Runtime/Events/IEvent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dc39dd6cb4164c989555c50ba3f40e4b
+timeCreated: 1700315575

--- a/Tests/Editor/Container/LazyTest.cs
+++ b/Tests/Editor/Container/LazyTest.cs
@@ -25,7 +25,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             var logger = FakeLogger();
 
-            container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
+            container.Configure(newDefaultLazyMode: LazyMode.NonLazy, newEnableEventBus: false);
 
             container.Register<ServiceWithLogger>();
             container.Register<SecondServiceWithLogger>();
@@ -40,7 +40,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             var logger = FakeLogger();
 
-            container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
+            container.Configure(newDefaultLazyMode: LazyMode.NonLazy, newEnableEventBus: false);
 
             container.Register<ServiceWithLogger>().Lazy();
             container.Register<SecondServiceWithLogger>();
@@ -55,7 +55,7 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
         {
             var logger = FakeLogger();
 
-            container.Configure(newDefaultLazyMode: LazyMode.NonLazy);
+            container.Configure(newDefaultLazyMode: LazyMode.NonLazy, newEnableEventBus: false);
 
             container.Register<ServiceWithLogger>().SetLazyMode(LazyMode.Lazy);
             container.Register<SecondServiceWithLogger>().SetLazyMode(LazyMode.NonLazy);

--- a/Tests/Editor/DucktionTest.cs
+++ b/Tests/Editor/DucktionTest.cs
@@ -33,7 +33,8 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
             container.Configure(
                 newLevel: config.LogLevel,
                 newEnableAutoResolve: config.EnableAutoResolve,
-                newAutoResolveSingletonMode: config.AutoResolveSingletonMode
+                newAutoResolveSingletonMode: config.AutoResolveSingletonMode,
+                newEnableEventBus: config.EnableEventBus
             );
 
             return container;

--- a/Tests/Editor/DucktionTestConfig.cs
+++ b/Tests/Editor/DucktionTestConfig.cs
@@ -9,18 +9,21 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
         public readonly LogLevel LogLevel;
         public readonly bool EnableAutoResolve;
         public readonly SingletonMode AutoResolveSingletonMode;
+        public readonly bool EnableEventBus;
 
         public DucktionTestConfig(
             bool createContainer = true,
             LogLevel logLevel = LogLevel.Disabled,
             bool enableAutoResolve = false,
-            SingletonMode autoResolveSingletonMode = SingletonMode.Singleton
+            SingletonMode autoResolveSingletonMode = SingletonMode.Singleton,
+            bool enableEventBus = false
         )
         {
             EnableAutoResolve = enableAutoResolve;
             AutoResolveSingletonMode = autoResolveSingletonMode;
             CreateContainer = createContainer;
             LogLevel = logLevel;
+            EnableEventBus = enableEventBus;
         }
     }
 }

--- a/Tests/Editor/Events.meta
+++ b/Tests/Editor/Events.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 10c4ed2dc6d848d29629fd6d83376411
+timeCreated: 1700316434

--- a/Tests/Editor/Events/SimpleEventBusTest.cs
+++ b/Tests/Editor/Events/SimpleEventBusTest.cs
@@ -1,0 +1,114 @@
+using System;
+using NUnit.Framework;
+using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs.Events;
+using TheRealIronDuck.Ducktion.Events;
+using TheRealIronDuck.Ducktion.Logging;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Events
+{
+    public class SimpleEventBusTest : DucktionTest
+    {
+        protected override DucktionTestConfig Configure() => new(
+            enableEventBus: true
+        );
+
+        [Test]
+        public void ItCanRegisterAndFireEvents()
+        {
+            var eventBus = container.Resolve<EventBus>();
+            var called = false;
+            
+            eventBus.Listen<ExampleEvent>(@event =>
+            {
+                Assert.AreEqual(123, @event.Value);
+                called = true;
+            });
+
+            eventBus.Fire(new ExampleEvent(123));
+            Assert.IsTrue(called);
+        }
+        
+        [Test]
+        public void ItCanRegisterMultipleListenersForTheSameEvent()
+        {
+            var eventBus = container.Resolve<EventBus>();
+            var called1 = false;
+            var called2 = false;
+            
+            eventBus.Listen<ExampleEvent>(@event =>
+            {
+                called1 = true;
+            });
+            
+            eventBus.Listen<ExampleEvent>(@event =>
+            {
+                called2 = true;
+            });
+
+            eventBus.Fire(new ExampleEvent(123));
+            Assert.IsTrue(called1);
+            Assert.IsTrue(called2);
+        }
+        
+        [Test]
+        public void ItLogsAnInfoIfNoListenersWereFound()
+        {
+            var logger = FakeLogger();
+            
+            var eventBus = container.Resolve<EventBus>();
+            
+            eventBus.Fire(new ExampleEvent(123));
+            
+            logger.AssertHasMessage(
+                LogLevel.Info,
+                $"No event listeners found for event {typeof(ExampleEvent)}"
+            );
+        }
+        
+        [Test]
+        public void ItCanForgetAListener()
+        {
+            var eventBus = container.Resolve<EventBus>();
+            var called = false;
+
+            Action<ExampleEvent> action = @event =>
+            {
+                Assert.AreEqual(123, @event.Value);
+                called = true;
+            };
+            eventBus.Listen<ExampleEvent>(action);
+
+            eventBus.Fire(new ExampleEvent(123));
+            Assert.IsTrue(called);
+
+            called = false;
+            
+            eventBus.Forget<ExampleEvent>(action);
+            eventBus.Fire(new ExampleEvent(123));
+            Assert.IsFalse(called);
+        }
+        
+        [Test]
+        public void ItCanClearAllListenersForASpecificEvent()
+        {
+            var eventBus = container.Resolve<EventBus>();
+            var called1 = false;
+            var called2 = false;
+
+            eventBus.Listen<ExampleEvent>(_ => called1 = true);
+            eventBus.Listen<ExampleEvent>(_ => called2 = true);
+            
+            eventBus.Fire(new ExampleEvent(123));
+            Assert.IsTrue(called1);
+            Assert.IsTrue(called2);
+
+            called1 = false;
+            called2 = false;
+
+            eventBus.Clear<ExampleEvent>();
+            eventBus.Fire(new ExampleEvent(123));
+            Assert.IsFalse(called1);
+            Assert.IsFalse(called2);
+        }
+    }
+}

--- a/Tests/Editor/Events/SimpleEventBusTest.cs.meta
+++ b/Tests/Editor/Events/SimpleEventBusTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f44d26cf546b4546826e27011fe273c7
+timeCreated: 1700316440

--- a/Tests/Editor/Stubs/Events.meta
+++ b/Tests/Editor/Stubs/Events.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e25a02be2f634410a2e1e93a0e13ed23
+timeCreated: 1700316650

--- a/Tests/Editor/Stubs/Events/ExampleEvent.cs
+++ b/Tests/Editor/Stubs/Events/ExampleEvent.cs
@@ -1,0 +1,14 @@
+using TheRealIronDuck.Ducktion.Events;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs.Events
+{
+    public class ExampleEvent : IEvent
+    {
+        public readonly int Value;
+        
+        public ExampleEvent(int value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/Tests/Editor/Stubs/Events/ExampleEvent.cs.meta
+++ b/Tests/Editor/Stubs/Events/ExampleEvent.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 32544dbb908a431f8fcf76bc40827091
+timeCreated: 1700316655


### PR DESCRIPTION
### Added
- Add simple event bus implementation
  - This can be enabled in the Container configuration
  - You can register event listeners for any events
  - Events must implement the `IEvent` interface