### PR TITLE
fix(resolve): Throw exception if auto resolving scriptable object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 - 2026-02-23
+### Fixed
+- Add error when trying to auto resolve scriptable object
+
 ## 0.1.0 - 2023-11-23
 ### Added
 - Created this package!

--- a/Runtime/DiContainer.cs
+++ b/Runtime/DiContainer.cs
@@ -584,6 +584,17 @@ namespace TheRealIronDuck.Ducktion
             // If the service isn't registered we just take the original type given. Otherwise we take the
             // registered type.
             var targetType = service?.ServiceType ?? type;
+
+            // If we try to dynamically create a scriptable object, throw an error. ScriptableObjects
+            // should NEVER be automatically resolved. They either should be manually registered OR
+            // resolved through an instance / callback.
+            if (typeof(ScriptableObject).IsAssignableFrom(targetType))
+            {
+                _logger?.Log(LogLevel.Error, $"Service {targetType} cant be resolved: Cannot auto resolve scriptable objects");
+
+                throw new DependencyResolveException(targetType, "Cannot auto resolve scriptable object.");
+            }
+
             var isAutoResolved = service == null;
 
             // Get all constructors. If there are more than one, we will throw an error

--- a/Tests/Editor/Container/AutoResolveTest.cs
+++ b/Tests/Editor/Container/AutoResolveTest.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
 using TheRealIronDuck.Ducktion.Enums;
+using TheRealIronDuck.Ducktion.Exceptions;
 
 namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
 {
@@ -18,49 +19,65 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Container
             Assert.NotNull(result);
             Assert.IsInstanceOf<SimpleService>(result);
         }
-        
+
         [Test]
         public void ItCanAutomaticallyResolveUnknownServicesRecursively()
         {
             var result = container.Resolve<SimpleServiceWithDependency>();
             Assert.NotNull(result);
             Assert.IsInstanceOf<SimpleServiceWithDependency>(result);
-            
+
             Assert.IsInstanceOf<AnotherService>(result.Another);
         }
-        
+
         [Test]
         public void ItCanMixAutomaticResolvesWithManuallyRegisteredInterfaces()
         {
             container.Register<ISimpleInterface, SimpleServiceWithDependency>();
-            
+
             var result = container.Resolve<ServiceWithDependencies>();
             Assert.NotNull(result);
             Assert.IsInstanceOf<ServiceWithDependencies>(result);
-            
+
             Assert.IsInstanceOf<SimpleServiceWithDependency>(result.Simple);
-            
+
             Assert.IsInstanceOf<AnotherService>((result.Simple as SimpleServiceWithDependency)?.Another);
         }
-        
+
         [Test]
         public void ItStoresThemAsSingletons()
         {
             var result1 = container.Resolve<SimpleService>();
             var result2 = container.Resolve<SimpleService>();
-            
+
             Assert.AreSame(result1, result2);
         }
-        
+
         [Test]
         public void ItCanOptionallyNotStoreThemAsSingletons()
         {
             container.Configure(newAutoResolveSingletonMode: SingletonMode.NonSingleton);
-            
+
             var result1 = container.Resolve<SimpleService>();
             var result2 = container.Resolve<SimpleService>();
-            
+
             Assert.AreNotSame(result1, result2);
+        }
+
+        [Test]
+        public void ItThrowsAnExceptionIfAScriptableObjectIsBeingResolvedWithoutBeingRegistered()
+        {
+            var failed = false;
+            try
+            {
+                container.Resolve<ServiceWithScriptableObject>();
+            }
+            catch (DependencyResolveException)
+            {
+                failed = true;
+            }
+
+            Assert.IsTrue(failed, "Resolving has not failed!");
         }
     }
 }

--- a/Tests/Editor/Container/IdTest.cs
+++ b/Tests/Editor/Container/IdTest.cs
@@ -1,4 +1,3 @@
-using System;
 using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
 using TheRealIronDuck.Ducktion.Exceptions;

--- a/Tests/Editor/Container/InstanceBindingTest.cs
+++ b/Tests/Editor/Container/InstanceBindingTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs;
 using TheRealIronDuck.Ducktion.Exceptions;
 using UnityEngine;

--- a/Tests/Editor/LoggingTest.cs
+++ b/Tests/Editor/LoggingTest.cs
@@ -261,5 +261,26 @@ namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor
                 $"Using configurator: {typeof(ExampleConfigurator)}"
             );
         }
+
+        [Test]
+        public void ItLogsAnErrorIfAScriptableObjectIsBeingResolvedWithoutBeingRegistered()
+        {
+            var logger = FakeLogger();
+            container.Configure(newEnableAutoResolve: true);
+
+            try
+            {
+                container.Resolve<ServiceWithScriptableObject>();
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            logger.AssertHasMessage(
+                LogLevel.Error,
+                $"Service {typeof(SimpleScriptableObject)} cant be resolved: Cannot auto resolve scriptable objects"
+            );
+        }
     }
 }

--- a/Tests/Editor/Stubs/ServiceWithScriptableObject.cs
+++ b/Tests/Editor/Stubs/ServiceWithScriptableObject.cs
@@ -1,0 +1,12 @@
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs
+{
+    public class ServiceWithScriptableObject
+    {
+        public SimpleScriptableObject someObject;
+
+        public ServiceWithScriptableObject(SimpleScriptableObject so)
+        {
+            someObject = so;
+        }
+    }
+}

--- a/Tests/Editor/Stubs/ServiceWithScriptableObject.cs.meta
+++ b/Tests/Editor/Stubs/ServiceWithScriptableObject.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: edff294563f148039a769b34b97f93f8
+timeCreated: 1771813891

--- a/Tests/Editor/Stubs/SimpleScriptableObject.cs
+++ b/Tests/Editor/Stubs/SimpleScriptableObject.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace TheRealIronDuck.Ducktion.Editor.Tests.Editor.Stubs
+{
+    public class SimpleScriptableObject : ScriptableObject
+    {
+        public int someData;
+    }
+}

--- a/Tests/Editor/Stubs/SimpleScriptableObject.cs.meta
+++ b/Tests/Editor/Stubs/SimpleScriptableObject.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3dd4b1dc71aa44b785899695d3994f01
+timeCreated: 1771813871

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 ﻿{
   "name": "com.therealironduck.ducktion",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "displayName": "Ducktion",
   "description": "Simple, flexible dependency injection for Unity!",
   "unity": "2022.3",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auto-resolution of ScriptableObjects is now blocked; attempting to resolve an unregistered ScriptableObject will raise an error and log a descriptive message.

* **Documentation**
  * Updated CHANGELOG with v0.1.1 release notes.

* **Chores**
  * Bumped package version to 0.1.1.
  * Removed unused imports from test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->